### PR TITLE
Try `&quest;` HTML Entity for `?` PHP tags

### DIFF
--- a/wordpress-coding-standards/php.md
+++ b/wordpress-coding-standards/php.md
@@ -214,15 +214,15 @@ if ( $a === $b ) { ?>
 Correct:
 
 [php]
-<?php ... ?>
-<?php echo $var; ?>
+<&quest;php ... &quest;>
+<&quest;php echo $var; &quest;>
 [/php]
 
 Incorrect:
 
 [php]
-<? ... ?>
-<?= $var ?>
+<&quest; ... &quest;>
+<&quest;= $var &quest;>
 [/php]
 
 <h3>Remove Trailing Spaces</h3>


### PR DESCRIPTION
Fixes #38

This PR tests the markdown passer by using `&quest;` instead of `?` for opening and closing PHP tags