### PR TITLE
Switch to using Markdown code fence notation instead of shortcodes and update style guide accordingly.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,6 @@
 # Changelog
 
+- 2020-09-25 Update code examples to use Markdown code fence notation instead of shortcodes.
 - 2019-12-21 Update `javascript.md` from the [handbook page](https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/).
 - 2019-12-21 Update `accessibility.md` from the [handbook page](https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/).
 - 2018-01-14 Initial import from https://make.wordpress.org/core/handbook/best-practices/

--- a/inline-documentation-standards/javascript.md
+++ b/inline-documentation-standards/javascript.md
@@ -62,12 +62,12 @@ Related comments should be spaced so that they align to make them more easily re
 
 For example:
 
-[js]
+```javascript
 /**
  * @param {very_long_type} name           Description.
  * @param {type}           very_long_name Description.
  */
-[/js]
+```
 
 <h2>Functions</h2>
 Functions should be formatted as follows:
@@ -93,7 +93,7 @@ Functions should be formatted as follows:
 	<li><strong>@return:</strong> Note the period after the description.</li>
 </ul>
 
-[js]
+```javascript
 /**
  * Summary. (use period)
  *
@@ -129,7 +129,7 @@ Functions should be formatted as follows:
  *
  * @return {type} Return value description.
  */
-[/js]
+```
 
 <h2>Backbone classes</h2>
 Backbone's <code>extend</code> calls should be formatted as follows:
@@ -160,7 +160,7 @@ Backbone's <code>initialize</code> functions should be formatted as follows:
 </li>
 </ul>
 
-[js]
+```javascript
 Class = Parent.extend( /** @lends namespace.Class.prototype */{
 	/**
 	 * Summary. (use period)
@@ -191,11 +191,11 @@ Class = Parent.extend( /** @lends namespace.Class.prototype */{
 		//Do stuff.
 	}
 } );
-[/js]
+```
 
 If a Backbone class does not have an initialize function it should be documented by using @inheritDoc as follows:
 
-[js]
+```javascript
 /**
  * Summary. (use period)
  *
@@ -220,7 +220,7 @@ If a Backbone class does not have an initialize function it should be documented
 Class = Parent.extend( /** @lends namespace.Class.prototype */{
 // Functions and properties.
 } );
-[/js]
+```
 
 <blockquote>Note: This currently doesn't provide the expected functionality due to a bug with JSDoc's inheritDoc tag. See the issue <a href="https://github.com/jsdoc3/jsdoc/issues/1012">here</a></blockquote>
 <h2>Local functions</h2>
@@ -228,7 +228,7 @@ At times functions will be assigned to a local variable before being assigned as
 Such functions should be marked as inner functions of the namespace that uses them using <code>~</code>.
 The functions should be formatted as follows:
 
-[js]
+```javascript
 /**
  * Function description, you can use any JSDoc here as long as the function remains private.
  *
@@ -257,7 +257,7 @@ Class = Parent.extend( /** @lends namespace.Class.prototype */{
 	 */
 	doStuff: doStuff,
 } );
-[/js]
+```
 
 <h2>Local ancestors</h2>
 At times classes will have Ancestors that are only assigned to a local variable. Such classes should be assigned to the namespace their children are and be made inner classes using <code>~</code>.
@@ -274,7 +274,7 @@ Class members should be formatted as follows:
 	<li><strong>@memberof:</strong> Optionally use this to override what class this is a member of.</li>
 </ul>
 
-[js]
+```javascript
 /**
  * Short description. (use period)
  *
@@ -287,7 +287,7 @@ Class members should be formatted as follows:
  * @member   {type} realName
  * @memberof className
  */
-[/js]
+```
 
 <h2>Namespaces</h2>
 Namespaces should be formatted as follows:
@@ -299,7 +299,7 @@ Namespaces should be formatted as follows:
 	<li><strong>@property:</strong> Properties that this namespace exposes. Use a period at the end.</li>
 </ul>
 
-[js]
+```javascript
 /**
  * Short description. (use period)
  *
@@ -310,25 +310,25 @@ Namespaces should be formatted as follows:
  *
  * @property {type} key Description.
  */
-[/js]
+```
 
 <h2>Inline Comments</h2>
 Inline comments inside methods and functions should be formatted as follows:
 <h3>Single line comments</h3>
 
-[js]
+```javascript
 // Extract the array values.
-[/js]
+```
 
 <h3>Multi-line comments</h3>
 
-[js]
+```javascript
 /*
  * This is a comment that is long enough to warrant being stretched over
  * the span of multiple lines. You'll notice this follows basically
  * the same format as the JSDoc wrapping and comment block style.
  */
-[/js]
+```
 
 <strong>Important note:</strong> Multi-line comments must not begin with <code>/**</code> (double asterisk). Use <code>/*</code> (single asterisk) instead.
 <h2>File Headers</h2>
@@ -338,7 +338,7 @@ Whenever possible, all WordPress JavaScript files should contain a header block.
 
 WordPress uses JSHint for general code quality testing. Any inline configuration options should be placed at the end of the header block.
 
-[js]
+```javascript
 /**
  * Summary. (use period)
  *
@@ -351,7 +351,7 @@ WordPress uses JSHint for general code quality testing. Any inline configuration
  */
  
 /** jshint {inline configuration here} */
-[/js]
+```
 
 <h2>Supported JSDoc Tags</h2>
 <table>

--- a/inline-documentation-standards/php.md
+++ b/inline-documentation-standards/php.md
@@ -90,7 +90,7 @@ HTML markup should never be used outside of code examples, though Markdown can b
 
 Use a hyphen (-) to create an unordered list, with a blank line before and after.
 
-[php]
+```php
  * Description which includes an unordered list:
  *
  * - This is item 1.
@@ -98,11 +98,11 @@ Use a hyphen (-) to create an unordered list, with a blank line before and after
  * - This is item 3.
  *
  * The description continues on ...
-[/php]
+```
 
 Use numbers to create an ordered list, with a blank line before and after.
 
-[php]
+```php
  * Description which includes an ordered list:
  *
  * 1. This is item 1.
@@ -110,11 +110,11 @@ Use numbers to create an ordered list, with a blank line before and after.
  * 3. This is item 3.
  *
  * The description continues on ...
-[/php]
+```
 
 2. Code samples would be created by indenting every line of the code by 4 spaces, with a blank line before and after. Blank lines in code samples also need to be indented by four spaces. Note that examples added in this way will be output in &lt;pre&gt; tags and <em>not</em> syntax-highlighted.
 
-[php]
+```php
  * Description including a code sample:
  *
  *    $status = array(
@@ -125,15 +125,15 @@ Use numbers to create an ordered list, with a blank line before and after.
  *    );
  *
  * The description continues on ...
-[/php]
+```
 
 3. Links in the form of URLs, such as related Trac tickets or other documentation, should be added in the appropriate place in the DocBlock using the <code>@link</code> tag:
 
-[php]
+```php
  * Description text.
  *
  * @link https://core.trac.wordpress.org/ticket/20000
-[/php]
+```
 
 <h4><code>@since</code> Section (Changelogs)</h4>
 Every function, hook, class, and method should have a corresponding <code>@since</code> version associated with it (more on that below).
@@ -142,9 +142,9 @@ No HTML should be used in the descriptions for <code>@since</code> tags, though 
 
 Versions should be expressed in the 3-digit <code>x.x.x</code> style:
 
-[php]
+```php
  * @since 4.4.0
-[/php]
+```
 
 If significant changes have been made to a function, hook, class, or method, additional <code>@since</code> tags, versions, and descriptions should be added to provide a changelog for that function.
 
@@ -157,11 +157,11 @@ If significant changes have been made to a function, hook, class, or method, add
 </ul>
 PHPDoc supports multiple <code>@since</code> versions in DocBlocks for this explicit reason. When adding changelog entries to the <code>@since</code> block, a version should be cited, and a description should be added in sentence case and form and end with a period:
 
-[php]
+```php
  * @since 3.0.0
  * @since 3.8.0 Added the `post__in` argument.
  * @since 4.1.0 The `$force` parameter is now optional.
-[/php]
+```
 
 <h4>Other Descriptions</h4>
 <code>@param</code>, <code>@type</code>, <code>@return</code>: No HTML should be used in the descriptions for these tags, though limited Markdown can be used as necessary, such as for adding backticks around variables, e.g. <code>`$variable`</code>.
@@ -194,7 +194,7 @@ Functions and class methods should be formatted as follows:
  	<li><strong>@return:</strong> Should contain all possible return types, and a description for each. Use a period at the end. Note: <code>@return</code> void should not be used outside of the default bundled themes.</li>
 </ul>
 
-[php]
+```php
 /**
  * Summary.
  *
@@ -211,21 +211,21 @@ Functions and class methods should be formatted as follows:
  * @param type $var Optional. Description. Default.
  * @return type Description.
  */
-[/php]
+```
 
 <h4>1.1 Parameters That Are Arrays</h4>
 Parameters that are an array of arguments should be documented in the "originating" function only, and cross-referenced via an <code>@see</code> tag in corresponding DocBlocks.
 
 Array values should be documented using WordPress' flavor of hash notation style similar to how <a href="http://make.wordpress.org/core/handbook/inline-documentation-standards/php-documentation-standards/#4-hooks-actions-and-filters">Hooks</a> can be documented, each array value beginning with the <code>@type</code> tag, and taking the form of:
 
-[php]
+```php
 *     @type type $key Description. Default 'value'. Accepts 'value', 'value'.
 *                     (aligned with Description, if wraps to a new line)
-[/php]
+```
 
 An example of an "originating" function and re-use of an argument array is <a href="https://core.trac.wordpress.org/browser/branches/4.0/src/wp-includes/http.php#L115"><code>wp_remote_request|post|get|head()</code></a>.
 
-[php]
+```php
 /**
  * Summary.
  *
@@ -244,13 +244,13 @@ An example of an "originating" function and re-use of an argument array is <a hr
  * @param type  $var Description.
  * @return type Description.
  */
-[/php]
+```
 
 In most cases, there is no need to mark individual arguments in a hash notation as <em>optional</em>, as the entire array is usually optional. Specifying "Optional." in the hash notation description should suffice. In the case where the array is NOT optional, individual key/value pairs may be optional and should be marked as such as necessary.
 <h4>1.2 Deprecated Functions</h4>
 If the function is deprecated and should not be used any longer, the <code>@deprecated</code> tag, along with the version and description of what to use instead, should be added. Note the additional use of an <code>@see</code> tag – the Code Reference uses this information to attempt to link to the replacement function.
 
-[php]
+```php
 /**
  * Summary.
  *
@@ -264,7 +264,7 @@ If the function is deprecated and should not be used any longer, the <code>@depr
  * @param type $var Description.
  * @return type Description.
  */
-[/php]
+```
 
 <h3>2. Classes</h3>
 Class DocBlocks should be formatted as follows:
@@ -274,7 +274,7 @@ Class DocBlocks should be formatted as follows:
  	<li><strong>@since x.x.x:</strong> Should always be 3-digit (e.g. <code>@since 3.9.0</code>). Exception is <code>@since MU (3.0.0)</code>.</li>
 </ul>
 
-[php]
+```php
 /**
  * Summary.
  *
@@ -282,11 +282,11 @@ Class DocBlocks should be formatted as follows:
  *
  * @since x.x.x
  */
-[/php]
+```
 
 If documenting a sub-class, it's also helpful to include an `@see` tag reference to the super class:
 
-[php]
+```php
 /**
  * Summary.
  *
@@ -296,7 +296,7 @@ If documenting a sub-class, it's also helpful to include an `@see` tag reference
  *
  * @see Super_Class
  */
-[/php]
+```
 
 <h4>2.1 Class Members</h4>
 <h5>2.1.1 Properties</h5>
@@ -307,14 +307,14 @@ Class properties should be formatted as follows:
  	<li><strong>@var:</strong> Formatted the same way as <code>@param</code>, though the description may be omitted.</li>
 </ul>
 
-[php]
+```php
 /**
  * Summary.
  *
  * @since x.x.x
  * @var type $var Description.
  */
-[/php]
+```
 
 <h5>2.1.2 Constants</h5>
 <ul>
@@ -323,7 +323,7 @@ Class properties should be formatted as follows:
  	<li><strong>@var:</strong> Formatted the same way as <code>@param</code>, though the description may be omitted.</li>
 </ul>
 
-[php]
+```php
 /**
  * Summary.
  *
@@ -331,17 +331,17 @@ Class properties should be formatted as follows:
  * @var type $var Description.
  */
 const NAME = value;
-[/php]
+```
 
 <h3>3. Requires and Includes</h3>
 Files required or included should be documented with a summary description DocBlock. Optionally, this may apply to inline <code>get_template_part()</code> calls as needed for clarity.
 
-[php]
+```php
 /**
  * Summary.
  */
 require_once( ABSPATH . WPINC . '/filename.php' );
-[/php]
+```
 
 <h3>4. Hooks (Actions and Filters)</h3>
 Both action and filter hooks should be documented on the line immediately preceding the call to <code>do_action()</code> or <code>do_action_ref_array()</code>, or <code>apply_filters()</code> or <code>apply_filters_ref_array()</code>, and formatted as follows:
@@ -354,7 +354,7 @@ Both action and filter hooks should be documented on the line immediately preced
 </ul>
 Note that <code>@return</code> is <em>not</em> used for hook documentation, because action hooks return nothing, and filter hooks always return their first parameter.
 
-[php]
+```php
 /**
  * Summary.
  *
@@ -371,7 +371,7 @@ Note that <code>@return</code> is <em>not</em> used for hook documentation, beca
  * }
  * @param type  $var Description.
  */
-[/php]
+```
 
 If a hook is in the middle of a block of HTML or a long conditional, the DocBlock should be placed on the line immediately before the start of the HTML block or conditional, even if it means forcing line-breaks/PHP tags in a continuous line of HTML.
 
@@ -381,34 +381,34 @@ Occasionally, hooks will be used multiple times in the same or separate core fil
 
 For actions:
 
-[php]
+```php
 /** This action is documented in path/to/filename.php */ 
-[/php]
+```
 
 For filters:
 
-[php]
+```php
 /** This filter is documented in path/to/filename.php */
-[/php]
+```
 
 To determine which instance should be documented, search for multiples of the same hook tag, then use <a href="http://make.wordpress.org/core/handbook/svn/code-history/#using-subversion-annotate">svn blame</a> to find the first use of the hook in terms of the earliest revision. If multiple instances of the hook were added in the same release, document the one most logically-placed as the "primary".
 <h3>5. Inline Comments</h3>
 Inline comments inside methods and functions should be formatted as follows:
 <h4>5.1 Single line comments</h4>
 
-[php]
+```php
 // Allow plugins to filter an array.
-[/php]
+```
 
 <h4>5.2 Multi-line comments</h4>
 
-[php]
+```php
 /* 
  * This is a comment that is long enough to warrant being stretched over
  * the span of multiple lines. You'll notice this follows basically
  * the same format as the PHPDoc wrapping and comment block style.
  */
-[/php]
+```
 
 <strong>Important note:</strong> Multi-line comments must not begin with <code>/**</code> (double asterisk) as the parser might mistake it for a DocBlock. Use <code>/*</code> (single asterisk) instead.
 <h3>6. File Headers</h3>
@@ -416,7 +416,7 @@ The file header DocBlock is used to give an overview of what is contained in the
 
 Whenever possible, <strong>all</strong> WordPress files should contain a header DocBlock, regardless of the file's contents – this includes files containing classes.
 
-[php]
+```php
 /**
  * Summary (no period for file headers)
  *
@@ -428,7 +428,7 @@ Whenever possible, <strong>all</strong> WordPress files should contain a header 
  * @subpackage Component
  * @since x.x.x (when the file was introduced)
  */
-[/php]
+```
 
 The <em>Summary</em> section is meant to serve as a succinct description of <strong>what</strong> specific purpose the file serves.
 
@@ -453,14 +453,14 @@ Constants should be formatted as follows:
  	<li><strong>@var:</strong> Formatted the same way as <code>@param</code>. The description is optional.</li>
 </ul>
 
-[php]
+```php
 /**
  * Summary.
  *
  * @since x.x.x (if available)
  * @var type $var Description.
  */
-[/php]
+```
 
 <h2>PHPDoc Tags</h2>
 Common PHPDoc tags used in WordPress include <code>@since</code>, <code>@see</code>, <code>@global</code> <code>@param</code>, and <code>@return</code> (see table below for full list).

--- a/styleguide.md
+++ b/styleguide.md
@@ -108,7 +108,7 @@ When documenting an example, use the markdown <code>`\``</code> code block to de
 
 #### Javascript
 ````
-```js
+```javascript
 var foo = function (bar) {
   return bar++;
 };

--- a/styleguide.md
+++ b/styleguide.md
@@ -95,18 +95,19 @@ Use `---` for a horizontal rules:
 
 ### Inline Code
 
-Wrap inline code with `\`` backticks:
-```md
+Wrap inline code with <code>`\``</code> backticks:
+````
+```
 This is `inline code` wrapped with backticks
 ```
+````
 
-When documenting an example, use the markdown ``\`\`` code block to demarcate the beginning and end of the code sample:
-
-**Note:** Full support for _fenced code blocks_ is not yet implemented for the handbooks, to workaround this see the shortcodes section below:
+When documenting an example, use the markdown <code>`\``</code> code block to demarcate the beginning and end of the code sample:
 
 ### Fenced Code Blocks
 
 #### Javascript
+````
 ```js
 var foo = function (bar) {
   return bar++;
@@ -114,8 +115,10 @@ var foo = function (bar) {
 
 console.log(foo(5));
 ```
+````
 
 #### JSON
+````
 ```json
 {
   "firstName": "John",
@@ -140,8 +143,10 @@ console.log(foo(5));
   "spouse": null
 }
 ```
+````
 
 #### CSS
+````
 ```css
 foo {
   padding: 5px;
@@ -152,8 +157,10 @@ foo {
   background-color: #f00;
 }
 ```
+````
 
 #### SCSS
+````
 ```scss
 foo {
   padding: 5px;
@@ -164,32 +171,28 @@ foo {
   background-color: #f00;
 }
 ```
+````
+
+#### HTML
+````
+```html
+<span class="my-class">Example</span>
+```
+````
 
 #### PHP
+````
 ```php
 $array = array(
     "foo" => "bar",
     "bar" => "foo",
 );
 ```
+````
 
 #### Markdown
+````
 ```md
 This is _italic text_. This is **bold text**.
 ```
-
-### Shortcodes
-
-#### Javascript
-Wrap multiline Javascript code in <code>[</code><code>javascript</code><code>]</code> and <code>[/javascript]</code> each on their own line.
-
-#### CSS & SCSS
-Wrap multiline CSS & SCSS code in <code>[</code><code>css</code><code>]</code> and <code>[/css]</code> each on their own line.
-
-#### PHP
-Wrap multiline PHP code in <code>[</code><code>php</code><code>]</code> and <code>[/php]</code> each on their own line.
-
-#### Markdown
-Wrap multiline Markdown code in <code>[</code><code>md</code><code>]</code> and <code>[/md]</code> each on their own line.
-
-**Note:** The <code>[md]</code> shortcode is also not currently supported.
+````

--- a/wordpress-coding-standards/css.md
+++ b/wordpress-coding-standards/css.md
@@ -12,25 +12,25 @@ There are plenty of different methods for structuring a stylesheet. With the CSS
 </ul>
 Correct:
 
-[css]
+```css
 #selector-1,
 #selector-2,
 #selector-3 {
 	background: #fff;
 	color: #000;
 }
-[/css]
+```
 
 Incorrect:
 
-[css]
+```css
 #selector-1, #selector-2, #selector-3 {
 	background: #fff;
 	color: #000;
 	}
 
 #selector-1 { background: #fff; color: #000; }
-[/css]
+```
 
 <h2>Selectors</h2>
 With specificity, comes great responsibility. Broad selectors allow us to be efficient, yet can have adverse consequences if not tested. Location-specific selectors can save us time, but will quickly lead to a cluttered stylesheet. Exercise your best judgement to create selectors that find the right balance between contributing to the overall style and layout of the DOM.
@@ -42,7 +42,7 @@ With specificity, comes great responsibility. Broad selectors allow us to be eff
 </ul>
 Correct:
 
-[css]
+```css
 #comment-form {
 	margin: 1em 0;
 }
@@ -50,11 +50,11 @@ Correct:
 input[type="text"] {
 	line-height: 1.1;
 }
-[/css]
+```
 
 Incorrect:
 
-[css]
+```css
 #commentForm { /&042; Avoid camelcase. &042;/
 	margin: 0;
 }
@@ -74,7 +74,7 @@ div#comment_form { /&042; Avoid over-qualification. &042;/
 input[type=text] { /&042; Should be [type="text"] &042;/
 	line-height: 110% /&042; Also doubly incorrect &042;/
 }
-[/css]
+```
 
 <h2>Properties</h2>
 Similar to selectors, properties that are too specific will hinder the flexibility of the design. Less is more. Make sure you are not repeating styling or introducing fixed dimensions (when a fluid solution is more acceptable).
@@ -86,25 +86,25 @@ Similar to selectors, properties that are too specific will hinder the flexibili
 </ul>
 Correct:
 
-[css]
+```css
 #selector-1 {
 	background: #fff;
 	display: block;
 	margin: 0;
 	margin-left: 20px;
 }
-[/css]
+```
 
 Incorrect:
 
-[css]
+```css
 #selector-1 {
 	background:#FFFFFF;
 	display: BLOCK;
 	margin-left: 20PX;
 	margin: 0;
 }
-[/css]
+```
 
 <h3>Property Ordering</h3>
 <blockquote>"Group like properties together, especially if you have a lot of them."
@@ -123,7 +123,7 @@ Top/Right/Bottom/Left (TRBL/trouble) should be the order for any relevant proper
 
 Example:
 
-[css]
+```css
 #overlay {
 	position: absolute;
 	z-index: 1;
@@ -131,13 +131,13 @@ Example:
 	background: #fff;
 	color: #777;
 }
-[/css]
+```
 
 Another method that is often used, including by the Automattic/WordPress.com Themes Team, is to order properties alphabetically, with or without certain exceptions.
 
 Example:
 
-[css]
+```css
 #overlay {
 	background: #fff;
 	color: #777;
@@ -145,20 +145,20 @@ Example:
 	position: absolute;
 	z-index: 1;
 }
-[/css]
+```
 
 <h3>Vendor Prefixes</h3>
 Updated on 2/13/2014, after <a href="https://core.trac.wordpress.org/changeset/27174">[27174]</a>:
 
 We use <a href="https://github.com/postcss/autoprefixer">Autoprefixer</a> as a pre-commit tool to easily manage necessary browser prefixes, thus making the majority of this section moot. For those interested in following that output without using Grunt, vendor prefixes should go longest (-webkit-) to shortest (unprefixed). All other spacing remains as per the rest of standards.
 
-[css]
+```css
 .sample-output {
 	-webkit-box-shadow: inset 0 0 1px 1px #eee;
 	-moz-box-shadow: inset 0 0 1px 1px #eee;
 	box-shadow: inset 0 0 1px 1px #eee;
 }
-[/css]
+```
 
 <h2>Values</h2>
 There are numerous ways to input values for properties. Follow the guidelines below to help us retain a high degree of consistency.
@@ -176,7 +176,7 @@ There are numerous ways to input values for properties. Follow the guidelines be
 </ul>
 Correct:
 
-[css]
+```css
 .class { /&042; Correct usage of quotes &042;/
 	background-image: url(images/bg.png);
 	font-family: "Helvetica Neue", sans-serif;
@@ -198,11 +198,11 @@ Correct:
 		0 0 0 1px #5b9dd9,
 		0 0 2px 1px rgba(30, 140, 190, 0.8);
 }
-[/css]
+```
 
 Incorrect:
 
-[css]
+```css
 .class { /&042; Avoid missing space and semicolon &042;/
 	background:#fff
 }
@@ -224,7 +224,7 @@ Incorrect:
 		0, 0.5),
 		0 1px 0 rgba(0,0,0,0.5);
 }
-[/css]
+```
 
 <h2>Media Queries</h2>
 Media queries allow us to gracefully degrade the DOM for different screen sizes. If you are adding any, be sure to test above and below the break-point you are targeting.
@@ -238,11 +238,11 @@ Media queries allow us to gracefully degrade the DOM for different screen sizes.
 </ul>
 Example:
 
-[css]
+```css
 @media all and (max-width: 699px) and (min-width: 520px) {
         /&042; Your selectors &042;/
 }
-[/css]
+```
 
 <h2>Commenting</h2>
 <ul>
@@ -252,27 +252,27 @@ Example:
 </ul>
 For sections and subsections:
 
-[css]
-/&042;&042;
-&042; #.# Section title
-&042;
-&042; Description of section, whether or not it has media queries, etc.
-&042;/
+```css
+/**
+* #.# Section title
+*
+* Description of section, whether or not it has media queries, etc.
+*/
 
 .selector {
 	float: left;
 }
-[/css]
+```
 
 For inline:
 
-[css]
-/&042; This is a comment about this selector &042;/
+```css
+/* This is a comment about this selector */
 .another-selector {
 	position: absolute;
-	top: 0 !important; /&042; I should explain why this is so !important &042;/
+	top: 0 !important; /* I should explain why this is so !important */
 }
-[/css]
+```
 
 <h2>Best Practices</h2>
 Stylesheets tend to get long in length. Focus slowly gets lost whilst intended goals start repeating and overlapping. Writing smart code from the outset helps us retain the overview whilst remaining flexible throughout change.

--- a/wordpress-coding-standards/css.md
+++ b/wordpress-coding-standards/css.md
@@ -254,10 +254,10 @@ For sections and subsections:
 
 ```css
 /**
-* #.# Section title
-*
-* Description of section, whether or not it has media queries, etc.
-*/
+ * #.# Section title
+ *
+ * Description of section, whether or not it has media queries, etc.
+ */
 
 .selector {
 	float: left;

--- a/wordpress-coding-standards/html.md
+++ b/wordpress-coding-standards/html.md
@@ -9,11 +9,15 @@ All HTML pages should be verified against [the W3C validator](https://validator.
 
 All tags must be properly closed. For tags that can wrap nodes such as text or other elements, termination is a trivial enough task. For tags that are self-closing, the forward slash should have exactly one space preceding it:
 
-[html]&lt;br /&gt;[/html]
+```html
+<br />
+```
 
 rather than the compact but incorrect:
 
-[html]&lt;br/&gt;[/html]
+```html
+<br/>
+```
 
 The W3C specifies that a single space should precede the self-closing slash ([source](https://w3.org/TR/xhtml1/#C_2)).
 
@@ -23,15 +27,15 @@ All tags and attributes must be written in lowercase. Additionally, attribute va
 
 For machines:
 
-[html]
-&lt;meta http-equiv="content-type" content="text/html; charset=utf-8" /&gt;
-[/html]
+```html
+<meta http-equiv="content-type" content="text/html; charset=utf-8" />
+```
 
 For humans:
 
-[html]
-&lt;a href="http://example.com/" title="Description Here"&gt;Example.com&lt;/a&gt;
-[/html]
+```html
+<a href="http://example.com/" title="Description Here">Example.com</a>
+```
 
 ### Quotes
 
@@ -39,16 +43,16 @@ According to the W3C specifications for XHTML, all attributes must have a value,
 
 Correct:
 
-[html]
-&lt;input type="text" name="email" disabled="disabled" /&gt;
-&lt;input type='text' name='email' disabled='disabled' /&gt;
-[/html]
+```html
+<input type="text" name="email" disabled="disabled" />
+<input type='text' name='email' disabled='disabled' />
+```
 
 Incorrect:
 
-[html]
-&lt;input type=text name=email disabled&gt;
-[/html]
+```html
+<input type=text name=email disabled>
+```
 
 In HTML, attributes do not all have to have values, and attribute values do not always have to be quoted. While all of the examples above are valid HTML, _failing to quote attributes can lead to security vulnerabilities_. Always quote attributes.
 
@@ -60,31 +64,31 @@ When mixing PHP and HTML together, indent PHP blocks to match the surrounding HT
 
 Correct:
 
-[php]
-&lt;?php if ( ! have_posts() ) : ?&gt;
-&lt;div id="post-1" class="post"&gt;
-&lt;h1 class="entry-title"&gt;Not Found&lt;/h1&gt;
-&lt;div class="entry-content"&gt;
-&lt;p&gt;Apologies, but no results were found.&lt;/p&gt;
-&lt;?php get_search_form(); ?&gt;
-&lt;/div&gt;
-&lt;/div&gt;
-&lt;?php endif; ?&gt;
-[/php]
+```php
+<?php if ( ! have_posts() ) : ?>
+<div id="post-1" class="post">
+<h1 class="entry-title">Not Found</h1>
+<div class="entry-content">
+<p>Apologies, but no results were found.</p>
+<?php get_search_form(); ?>
+</div>
+</div>
+<?php endif; ?>
+```
 
 Incorrect:
 
-[php]
-&lt;?php if ( ! have_posts() ) : ?&gt;
-&lt;div id="post-0" class="post error404 not-found"&gt;
-&lt;h1 class="entry-title"&gt;Not Found&lt;/h1&gt;
-&lt;div class="entry-content"&gt;
-&lt;p&gt;Apologies, but no results were found.&lt;/p&gt;
-&lt;?php get_search_form(); ?&gt;
-&lt;/div&gt;
-&lt;/div&gt;
-&lt;?php endif; ?&gt;
-[/php]
+```php
+<?php if ( ! have_posts() ) : ?>
+<div id="post-0" class="post error404 not-found">
+<h1 class="entry-title">Not Found</h1>
+<div class="entry-content">
+<p>Apologies, but no results were found.</p>
+<?php get_search_form(); ?>
+</div>
+</div>
+<?php endif; ?>
+```
 
 ## Credits
 

--- a/wordpress-coding-standards/javascript.md
+++ b/wordpress-coding-standards/javascript.md
@@ -218,7 +218,7 @@ elements
 		.html( 'hello' )
 	.end()
 	.appendTo( 'body' );
-	```
+```
 
 ## Assignments and Globals
 
@@ -530,7 +530,8 @@ var arr = _.chain( obj )
 	// Exit the chain
 	.value();
 
-// arr === [ 'first comes thing 1', 'second comes thing 2', 'third comes lox' ]```
+// arr === [ 'first comes thing 1', 'second comes thing 2', 'third comes lox' ]
+```
 
 ### Iterating Over jQuery Collections
 

--- a/wordpress-coding-standards/javascript.md
+++ b/wordpress-coding-standards/javascript.md
@@ -55,7 +55,7 @@ Object declarations can be made on a single line if they are short (remember the
 
 Objects and arrays can be declared on a single line if they are short (remember the line length guidelines). When an object or array is too long to fit on one line, each member must be placed on its own line and each line ended by a comma.
 
-[javascript]
+```javascript
 // Preferred
 var obj = {
 	ready: 9,
@@ -77,13 +77,13 @@ var obj = { ready: 9,
 	when: 4, 'you are': 15 };
 var arr = [ 9,
 	4, 15 ];
-[/javascript]
+```
 
 ### Arrays and Function Calls
 
 Always include extra spaces around elements and arguments:
 
-[javascript]
+```javascript
 array = [ a, b ];
  
 foo( arg );
@@ -97,11 +97,11 @@ foo( node, 'property', 2 );
 prop = object[ 'default' ];
  
 firstArrayElement = arr[ 0 ];
-[/javascript]
+```
 
 ### Examples of Good Spacing
 
-[javascript]
+```javascript
 var i;
 
 if ( condition ) {
@@ -131,7 +131,7 @@ try {
 } catch ( e ) {
 	// Expressions
 }
-[/javascript]
+```
 
 ## Semicolons
 
@@ -143,7 +143,7 @@ Indentation and line breaks add readability to complex statements.
 
 Tabs should be used for indentation. Even if the entire file is contained in a closure (i.e., an immediately invoked function), the contents of that function should be indented by one tab:
 
-[javascript]
+```javascript
 ( function ( $ ) {
 	// Expressions indented
 
@@ -151,13 +151,13 @@ Tabs should be used for indentation. Even if the entire file is contained in a c
 		// Expressions indented
 	}
 } )( jQuery );
-[/javascript]
+```
 
 ### Blocks and Curly Braces
 
 `if`, `else`, `for`, `while`, and `try` blocks should always use braces, and always go on multiple lines. The opening brace should be on the same line as the function definition, the conditional, or the loop. The closing brace should be on the line directly following the last statement of the block.
 
-[javascript]
+```javascript
 var a, b, c;
 
 if ( myFunction() ) {
@@ -167,13 +167,13 @@ if ( myFunction() ) {
 } else {
 	// Expressions
 }
-[/javascript]
+```
 
 ### Multi-line Statements
 
 When a statement is too long to fit on one line, line breaks must occur after an operator.
 
-[javascript]
+```javascript
 // Bad
 var html = '&lt;p>The sum of ' + a + ' and ' + b + ' plus ' + c
 	+ ' is ' + ( a + b + c ) + '&lt;/p>';
@@ -181,11 +181,11 @@ var html = '&lt;p>The sum of ' + a + ' and ' + b + ' plus ' + c
 // Good
 var html = '&lt;p>The sum of ' + a + ' and ' + b + ' plus ' + c +
 	' is ' + ( a + b + c ) + '&lt;/p>';
-[/javascript]
+```
 
 Lines should be broken into logical groups if it improves readability, such as splitting each expression of a ternary operator onto its own line, even if both will fit on a single line.
 
-[javascript]
+```javascript
 // Acceptable
 var baz = ( true === conditionalStatement() ) ? 'thing 1' : 'thing 2';
 
@@ -193,11 +193,11 @@ var baz = ( true === conditionalStatement() ) ? 'thing 1' : 'thing 2';
 var baz = firstCondition( foo ) &amp;&amp; secondCondition( bar ) ?
 	qux( foo, bar ) :
 	foo;
-[/javascript]
+```
 
 When a conditional is too long to fit on one line, each operand of a logical operator in the boolean expression must appear on its own line, indented one extra level from the opening and closing parentheses.
 
-[javascript]
+```javascript
 if (
 	firstCondition() &amp;&amp;
 	secondCondition() &amp;&amp;
@@ -205,20 +205,20 @@ if (
 ) {
     doStuff();
 }
-[/javascript]
+```
 
 ### Chained Method Calls
 
 When a chain of method calls is too long to fit on one line, there must be one call per line, with the first call on a separate line from the object the methods are called on. If the method changes the context, an extra level of indentation must be used.
 
-[javascript]
+```javascript
 elements
 	.addClass( 'foo' )
 	.children()
 		.html( 'hello' )
 	.end()
 	.appendTo( 'body' );
-	[/javascript]
+	```
 
 ## Assignments and Globals
 
@@ -234,7 +234,7 @@ Each function should begin with a single comma-delimited `var` statement that de
 
 Assignments within the `var` statement should be listed on individual lines, while declarations can be grouped on a single line. Any additional lines should be indented with an additional tab. Objects and functions that occupy more than a handful of lines should be assigned outside of the `var` statement, to avoid over-indentation.
 
-[javascript]
+```javascript
 // Good
 var k, m, length,
 	// Indent subsequent lines by one tab
@@ -246,7 +246,7 @@ var bar = false;
 var a;
 var b;
 var c;
-[/javascript]
+```
 
 ### Globals
 
@@ -256,9 +256,9 @@ All globals used within a file should be documented at the top of that file. Mul
 
 This example would make `passwordStrength` an allowed global variable within that file:
 
-[javascript]
+```javascript
 /* global passwordStrength:true */
-[/javascript]
+```
 
 The "true" after `passwordStrength` means that this global is being defined within this file. If you are accessing a global which is defined elsewhere, omit `:true` to designate the global as read-only.
 
@@ -268,20 +268,20 @@ Backbone, jQuery, Underscore, and the global `wp` object are all registered as a
 
 Backbone and Underscore may be accessed directly at any time. jQuery should be accessed through `$` by passing the `jQuery` object into an anonymous function:
 
-[javascript]
+```javascript
 ( function ( $ ) {
 	// Expressions
 } )( jQuery );
-[/javascript]
+```
 
 This will negate the need to call `.noConflict()`, or to set `$` using another variable.
 
 Files which add to, or modify, the `wp` object must safely access the global to avoid overwriting previously set properties:
 
-[javascript]
+```javascript
 // At the top of the file, set "wp" to its existing value (if present)
 window.wp = window.wp || {};
-[/javascript]
+```
 
 ## Naming Conventions
 
@@ -297,7 +297,7 @@ All other [abbreviations](https://en.wikipedia.org/wiki/Abbreviation) must be wr
 
 If an abbreviation or an acronym occurs at the start of a variable name, it must be written to respect the camelcase naming rules covering the first letter of a variable or class definition. For variable assignment, this means writing the abbreviation entirely as lowercase. For class definitions, its initial letter should be capitalized.
 
-[javascript]
+```javascript
 // "Id" is an abbreviation of "Identifier":
 const userId = 1;
  
@@ -309,7 +309,7 @@ const currentDOMDocument = window.document;
 const domDocument = window.document;
 class DOMDocument {}
 class IdCollection {}
-[/javascript]
+```
 
 ### Class Definitions
 
@@ -317,7 +317,7 @@ Constructors intended for use with `new` should have a capital first letter (Upp
 
 A [`class` definition](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes) must use the UpperCamelCase convention, regardless of whether it is intended to be used with `new` construction.
 
-[javascript]
+```javascript
 class Earth {
 	static addHuman( human ) {
 		Earth.humans.push( human );
@@ -329,7 +329,7 @@ class Earth {
 }
  
 Earth.humans = [];
-[/javascript]
+```
 
 All [`@wordpress/element`](https://www.npmjs.com/package/@wordpress/element) Components, including stateless function components, should be named using Class Definition naming rules, both for consistency and to reflect the fact that a component may need to be transitioned from a function to a class without breaking compatibility.
 
@@ -343,7 +343,7 @@ In almost all cases, a constant should be defined in the top-most scope of a fil
 
 Comments come before the code to which they refer, and should always be preceded by a blank line. Capitalize the first letter of the comment, and include a period at the end when writing full sentences. There must be a single space between the comment token (`//`) and the comment text.
 
-[javascript]
+```javascript
 someStatement();
  
 // Explanation of something complex on the next line
@@ -351,17 +351,17 @@ $( 'p' ).doSomething();
  
 // This is a comment that is long enough to warrant being stretched
 // over the span of multiple lines.
-[/javascript]
+```
 
 JSDoc comments should use the `/**` multi-line comment opening. Refer to the [JavaScript Documentation Standards](https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/#multi-line-comments) for more information.
 
 Inline comments are allowed as an exception when used to annotate special arguments in formal parameter lists:
 
-[javascript]
+```javascript
 function foo( types, selector, data, fn, /* INTERNAL */ one ) {
 	// Do stuff
 }
-[/javascript]
+```
 
 ## Equality
 
@@ -392,16 +392,16 @@ Anywhere Backbone or Underscore are already used, you are encouraged to use [Und
 
 Use single-quotes for string literals:
 
-[javascript]
+```javascript
 var myStr = 'strings should be contained in single quotes';
-[/javascript]
+```
 
 When a string contains single quotes, they need to be escaped with a backslash (`\`):
 
-[javascript]
+```javascript
 // Escape single quotes within strings:
 'Note the backslash before the \'single quotes\'';
-[/javascript]
+```
 
 ## Switch Statements
 
@@ -412,7 +412,7 @@ When using `switch` statements:
 - Use a `break` for each case other than `default`. When allowing statements to "fall through," note that explicitly.
 - Indent `case` statements one tab within the `switch`.
 
-[javascript]
+```javascript
 switch ( event.keyCode ) {
 	// ENTER and SPACE both trigger x()
 	case $.ui.keyCode.ENTER:
@@ -425,11 +425,11 @@ switch ( event.keyCode ) {
 	default:
 		z();
 }
-[/javascript]
+```
 
 It is not recommended to return a value from within a switch statement: use the `case` blocks to set values, then `return` those values at the end.
 
-[javascript]
+```javascript
 function getKeyCode( keyCode ) {
 	var result;
 
@@ -447,7 +447,7 @@ function getKeyCode( keyCode ) {
 
 	return result;
 }
-[/javascript]
+```
 
 ## Best Practices
 
@@ -455,15 +455,15 @@ function getKeyCode( keyCode ) {
 
 Creating arrays in JavaScript should be done using the shorthand `[]` constructor rather than the `new Array()` notation.
 
-[javascript]
+```javascript
 var myArray = [];
-[/javascript]
+```
 
 You can initialize an array during construction:
 
-[javascript]
+```javascript
 var myArray = [ 1, 'WordPress', 2, 'Blog' ];
-[/javascript]
+```
 
 In JavaScript, associative arrays are defined as objects.
 
@@ -471,29 +471,29 @@ In JavaScript, associative arrays are defined as objects.
 
 There are many ways to create objects in JavaScript. Object literal notation, `{}`, is both the most performant, and also the easiest to read.
 
-[javascript]
+```javascript
 var myObj = {};
-[/javascript]
+```
 
 Object literal notation should be used unless the object requires a specific prototype, in which case the object should be created by calling a constructor function with `new`.
 
-[javascript]
+```javascript
 var myObj = new ConstructorMethod();
-[/javascript]
+```
 
 Object properties should be accessed via dot notation, unless the key is a variable or a string that would not be a valid identifier:
 
-[javascript]
+```javascript
 prop = object.propertyName;
 prop = object[ variableKey ];
 prop = object['key-with-hyphens'];
-[/javascript]
+```
 
 ### Iteration
 
 When iterating over a large collection using a `for` loop, it is recommended to store the loop's max value as a variable rather than re-computing the maximum every time:
 
-[javascript]
+```javascript
 // Good &amp; Efficient
 var i, max;
 
@@ -507,7 +507,7 @@ for ( i = 0, max = getItemCount(); i &lt; max; i++ ) {
 for ( i = 0; i &lt; getItemCount(); i++ ) {
 	// Do stuff
 }
-[/javascript]
+```
 
 ### Underscore.js Collection Functions
 
@@ -515,7 +515,7 @@ Learn and understand Underscore's [collection and array methods](http://undersco
 
 Underscore also permits jQuery-style chaining with regular JavaScript objects:
 
-[javascript]
+```javascript
 var obj = {
 	first: 'thing 1',
 	second: 'thing 2',
@@ -530,19 +530,19 @@ var arr = _.chain( obj )
 	// Exit the chain
 	.value();
 
-// arr === [ 'first comes thing 1', 'second comes thing 2', 'third comes lox' ][/javascript]
+// arr === [ 'first comes thing 1', 'second comes thing 2', 'third comes lox' ]```
 
 ### Iterating Over jQuery Collections
 
 The only time jQuery should be used for iteration is when iterating over a collection of jQuery objects:
 
-[javascript]
+```javascript
 $tabs.each( function ( index, element ) {
 	var $element = $( element );
 
 	// Do stuff to $element
 } );
-[/javascript]
+```
 
 Never use jQuery to iterate over raw data or vanilla JavaScript objects.
 
@@ -584,14 +584,14 @@ In some situations, parts of a file should be excluded from JSHint. As an exampl
 
 To exclude a specific file region from being processed by JSHint, enclose it in JSHint directive comments:
 
-[javascript]
+```javascript
 /* jshint ignore:start */
 if ( typeof jQuery.fn.hoverIntent === 'undefined' ) {
 	// hoverIntent r6 - Copy of wp-includes/js/hoverIntent.min.js
 	(function(a){a.fn.hoverIntent=...............
 }
 /* jshint ignore:end */
-[/javascript]
+```
 
 ## Credits
 

--- a/wordpress-coding-standards/php.md
+++ b/wordpress-coding-standards/php.md
@@ -9,10 +9,10 @@ See also: <a href="https://developer.wordpress.org/coding-standards/inline-docum
 <h3>Single and Double Quotes</h3>
 Use single and double quotes when appropriate. If you're not evaluating anything in the string, use single quotes. You should almost never have to escape quotes in a string, because you can just alternate your quoting style, like so:
 
-[php]
+```php
 echo '<a href="/static/link" title="Yeah yeah!">Link name</a>';
 echo "<a href='$link' title='$linktitle'>$linkname</a>";
-[/php]
+```
 
 Text that goes into attributes should be run through <code>esc_attr()</code> so that single or double quotes do not end the attribute value and invalidate the HTML and cause a security issue. See <a href="http://codex.wordpress.org/Data_Validation">Data Validation</a> in the Codex for further details.
 <h3>Indentation</h3>
@@ -20,58 +20,58 @@ Your indentation should always reflect logical structure. Use <strong>real tabs<
 
 Exception: if you have a block of code that would be more readable if things are aligned, use spaces:
 
-[php]
-[tab]$foo   = 'somevalue';
-[tab]$foo2  = 'somevalue2';
-[tab]$foo34 = 'somevalue3';
-[tab]$foo5  = 'somevalue4';
-[/php]
+```php
+	$foo   = 'somevalue';
+	$foo2  = 'somevalue2';
+	$foo34 = 'somevalue3';
+	$foo5  = 'somevalue4';
+```
 
 For associative arrays, <em>each item</em> should start on a new line when the array contains more than one item:
 
-[php]
+```php
 $query = new WP_Query( array( 'ID' => 123 ) );
-[/php]
+```
 
-[php]
+```php
 $args = array(
-[tab]'post_type'   => 'page',
-[tab]'post_author' => 123,
-[tab]'post_status' => 'publish',
+	'post_type'   => 'page',
+	'post_author' => 123,
+	'post_status' => 'publish',
 );
  
 $query = new WP_Query( $args );
-[/php]
+```
 
 Note the comma after the last array item: this is recommended because it makes it easier to change the order of the array, and makes for cleaner diffs when new items are added.
 
-[php]
+```php
 $my_array = array(
 [tab]'foo'   => 'somevalue',
 [tab]'foo2'  => 'somevalue2',
 [tab]'foo3'  => 'somevalue3',
 [tab]'foo34' => 'somevalue3',
 );
-[/php]
+```
 
 For <code>switch</code> structures <code>case</code> should indent one tab from the <code>switch</code> statement and <code>break</code> one tab from the <code>case</code> statement.
 
-[php]
+```php
 switch ( $type ) {
-[tab]case 'foo':
-[tab][tab]some_function();
-[tab][tab]break;
-[tab]case 'bar':
-[tab][tab]some_function();
-[tab][tab]break;
+	case 'foo':
+		some_function();
+		break;
+	case 'bar':
+		some_function();
+		break;
 }
-[/php]
+```
 
 <strong>Rule of thumb:</strong> Tabs should be used at the beginning of the line for indentation, while spaces can be used mid-line for alignment.
 <h3>Brace Style</h3>
 Braces shall be used for all blocks in the style shown here:
 
-[php]
+```php
 if ( condition ) {
 	action1();
 	action2();
@@ -81,13 +81,13 @@ if ( condition ) {
 } else {
 	defaultaction();
 }
-[/php]
+```
 
 If you have a really long block, consider whether it can be broken into two or more shorter blocks, functions, or methods, to reduce complexity, improve ease of testing, and increase readability.
 
 Braces should always be used, even when they are not required:
 
-[php]
+```php
 if ( condition ) {
 	action0();
 }
@@ -102,11 +102,11 @@ if ( condition ) {
 foreach ( $items as $item ) {
 	process_item( $item );
 }
-[/php]
+```
 
 Note that requiring the use of braces just means that <em>single-statement inline control structures</em> are prohibited. You are free to use the <a href="http://php.net/manual/en/control-structures.alternative-syntax.php" rel="nofollow">alternative syntax for control structures</a> (e.g. <code>if</code>/<code>endif</code>, <code>while</code>/<code>endwhile</code>)—especially in your templates where PHP code is embedded within HTML, for instance:
 
-[php]
+```php
 <?php if ( have_posts() ) : ?>
 	<div class="hfeed">
 		<?php while ( have_posts() ) : the_post(); ?>
@@ -116,7 +116,7 @@ Note that requiring the use of braces just means that <em>single-statement inlin
 		<?php endwhile; ?>
 	</div>
 <?php endif; ?>
-[/php]
+```
 
 <h3>Use <code>elseif</code>, not <code>else if</code></h3>
 <code>else if</code> is not compatible with the colon syntax for <code>if|elseif</code> blocks. For this reason, use <code>elseif</code> for conditionals.
@@ -131,7 +131,7 @@ Arrays must be declared using long array syntax.
 
 Where appropriate, closures may be used as an alternative to creating new functions to pass as callbacks. For example:
 
-[php]
+```php
 $caption = preg_replace_callback(
     '/<[a-zA-Z0-9]+(?: [^<>]+>)*/',
     function ( $matches ) {
@@ -139,7 +139,7 @@ $caption = preg_replace_callback(
     },
     $caption
 );
-[/php]
+```
 
 Closures must not be passed as filter or action callbacks, as they cannot be removed by <code>remove_action()</code> / <code>remove_filter()</code> (see <a href="https://core.trac.wordpress.org/ticket/46635">#46635</a> for a proposal to address this).
 
@@ -149,7 +149,7 @@ When splitting a function call over multiple lines, each parameter must be on a 
 
 Each parameter must take up no more than a single line. Multi-line parameter values must be assigned to a variable and then that variable should be passed to the function call.
 
-[php]
+```php
 $bar = array(
     'use_this' => true,
     'meta_key' => 'field_name',
@@ -166,7 +166,7 @@ $a = foo(
     /* translators: %s: cat */
     sprintf( __( 'The best pet is a %s.' ), 'cat' )
 );
-[/php]
+```
 
 <h3>Regular Expressions</h3>
 Perl compatible regular expressions (<a href="http://php.net/pcre">PCRE</a>, <code>preg_</code> functions) should be used in preference to their POSIX counterparts. Never use the <code>/e</code> switch, use <code>preg_replace_callback</code> instead.
@@ -179,7 +179,7 @@ When embedding multi-line PHP snippets within a HTML block, the PHP open and clo
 
 Correct (Multiline):
 
-[php]
+```php
 function foo() {
     ?>
         <div>
@@ -192,91 +192,91 @@ function foo() {
         </div>
     <?php
 }
-[/php]
+```
 
 Correct (Single Line):
 
-[php]
+```php
 <input name="<?php echo esc_attr( $name ); ?>" />
-[/php]
+```
 
 Incorrect:
 
-[php]
+```php
 if ( $a === $b ) { ?>
 <some html>
 <?php }
-[/php]
+```
 
 <h3>No Shorthand PHP Tags</h3>
 <strong>Important:</strong> Never use shorthand PHP start tags. Always use full PHP tags.
 
 Correct:
 
-[php]
-<&quest;php ... &quest;>
-<&quest;php echo $var; &quest;>
-[/php]
+```php
+<?php ... ?>
+<?php echo $var; ?>
+```
 
 Incorrect:
 
-[php]
-<&quest; ... &quest;>
-<&quest;= $var &quest;>
-[/php]
+```php
+<? ... ?>
+<?= $var ?>
+```
 
 <h3>Remove Trailing Spaces</h3>
 Remove trailing whitespace at the end of each line of code. Omitting the closing PHP tag at the end of a file is preferred. If you use the tag, make sure you remove trailing whitespace.
 <h3>Space Usage</h3>
 Always put spaces after commas, and on both sides of logical, comparison, string and assignment operators.
 
-[php]
+```php
 x === 23
 foo && bar
 ! foo
 array( 1, 2, 3 )
 $baz . '-5'
 $term .= 'X'
-[/php]
+```
 
 Put spaces on both sides of the opening and closing parentheses of <code>if</code>, <code>elseif</code>, <code>foreach</code>, <code>for</code>, and <code>switch</code> blocks.
 
-[php]
+```php
 foreach ( $foo as $bar ) { ...
-[/php]
+```
 
 When defining a function, do it like so:
 
-[php]
+```php
 function my_function( $param1 = 'foo', $param2 = 'bar' ) { ...
 
 function my_other_function() { ...
-[/php]
+```
 
 When calling a function, do it like so:
 
-[php]
+```php
 my_function( $param1, func_param( $param2 ) );
 my_other_function();
-[/php]
+```
 
 When performing logical comparisons, do it like so:
 
-[php]
+```php
 if ( ! $foo ) { ...
-[/php]
+```
 
 <a title="type casting" href="http://www.php.net/manual/en/language.types.type-juggling.php#language.types.typecasting" target="_blank">Type casts</a> must be lowercase. Always prefer the short form of type casts, <code>(int)</code> instead of <code>(integer)</code> and <code>(bool)</code> rather than <code>(boolean)</code>. For float casts use <code>(float)</code>.:
 
-[php]
+```php
 foreach ( (array) $foo as $bar ) { ...
 
 $foo = (bool) $bar;
-[/php]
+```
 
 When referring to array items, only include a space around the index if it is a variable, for example:
 
-[php]
+```php
 $x = $foo['bar']; // correct
 $x = $foo[ 'bar' ]; // incorrect
 
@@ -285,32 +285,32 @@ $x = $foo[ 0 ]; // incorrect
 
 $x = $foo[ $bar ]; // correct
 $x = $foo[$bar]; // incorrect
-[/php]
+```
 
 In a <code>switch</code> block, there must be no space before the colon for a case statement.
 
-[php]
+```php
 switch ( $foo ) {
 	case 'bar': // correct
 	case 'ba' : // incorrect
 }
-[/php]
+```
 
 Similarly, there should be no space before the colon on return type declarations.
 
-[php]
+```php
 function sum( $a, $b ): float {
 	return $a + $b;
 }
-[/php]
+```
 
 Unless otherwise specified, parentheses should have spaces inside of them.
 
-[php]
+```php
 if ( $foo && ( $bar || $baz ) ) { ...
 
 my_function( ( $x - 1 ) * 5, $y );
-[/php]
+```
 
 <h3>Formatting SQL statements</h3>
 When formatting SQL statements you may break it into several lines and indent if it is sufficiently complex to warrant it. Most statements work well as one line though. Always capitalize the SQL parts of the statement like <code>UPDATE</code> or <code>WHERE</code>.
@@ -319,12 +319,12 @@ Functions that update the database should expect their parameters to lack SQL sl
 
 <code>$wpdb-&gt;prepare()</code> is a method that handles escaping, quoting, and int-casting for SQL queries. It uses a subset of the <code>sprintf()</code> style of formatting. Example :
 
-[php]
+```php
 $var = "dangerous'"; // raw data that may or may not need to be escaped
 $id = some_foo_number(); // data we expect to be an integer, but we're not certain
 
 $wpdb->query( $wpdb->prepare( "UPDATE $wpdb->posts SET post_title = %s WHERE ID = %d", $var, $id ) );
-[/php]
+```
 
 <code>%s</code> is used for string placeholders and <code>%d</code> is used for integer placeholders. Note that they are not 'quoted'! <code>$wpdb-&gt;prepare()</code> will take care of escaping and quoting for us. The benefit of this is that we don't have to remember to manually use <code><a href="https://developer.wordpress.org/reference/functions/esc_sql/">esc_sql</a>()</code>, and also that it is easy to see at a glance whether something has been escaped or not, because it happens right when the query happens.
 
@@ -336,47 +336,47 @@ If you must touch the database, get in touch with some developers by posting a m
 <h3>Naming Conventions</h3>
 Use lowercase letters in variable, action/filter, and function names (never <code>camelCase</code>). Separate words via underscores. Don't abbreviate variable names unnecessarily; let the code be unambiguous and self-documenting.
 
-[php]
+```php
 function some_name( $some_variable ) { [...] }
-[/php]
+```
 
 Class names should use capitalized words separated by underscores. Any acronyms should be all upper case.
 
-[php]
+```php
 class Walker_Category extends Walker { [...] }
 class WP_HTTP { [...] }
-[/php]
+```
 
 Constants should be in all upper-case with underscores separating words:
 
-[php]
+```php
 define( 'DOING_AJAX', true );
-[/php]
+```
 
 Files should be named descriptively using lowercase letters. Hyphens should separate words.
 
-[php]
+```php
 my-plugin-name.php
-[/php]
+```
 
 Class file names should be based on the class name with <code>class-</code> prepended and the underscores in the class name replaced with hyphens, for example <code>WP_Error</code> becomes:
 
-[php]
+```php
 class-wp-error.php
-[/php]
+```
 
 This file-naming standard is for all current and new files with classes. There is one exception for three files that contain code that got ported into BackPress: class.wp-dependencies.php, class.wp-scripts.php, class.wp-styles.php. Those files are prepended with <code>class.</code>, a dot after the word class instead of a hyphen.
 
 Files containing template tags in <code>wp-includes</code> should have <code>-template</code> appended to the end of the name so that they are obvious.
 
-[php]
+```php
 general-template.php
-[/php]
+```
 
 <h3>Self-Explanatory Flag Values for Function Arguments</h3>
 Prefer string values to just <code>true</code> and <code>false</code> when calling functions.
 
-[php]
+```php
 // Incorrect
 function eat( $what, $slowly = true ) {
 ...
@@ -384,11 +384,11 @@ function eat( $what, $slowly = true ) {
 eat( 'mushrooms' );
 eat( 'mushrooms', true ); // what does true mean?
 eat( 'dogfood', false ); // what does false mean? The opposite of true?
-[/php]
+```
 
 Since PHP doesn't support named arguments, the values of the flags are meaningless, and each time we come across a function call like the examples above, we have to search for the function definition. The code can be made more readable by using descriptive string values, instead of booleans.
 
-[php]
+```php
 // Correct
 function eat( $what, $speed = 'slowly' ) {
 ...
@@ -396,17 +396,17 @@ function eat( $what, $speed = 'slowly' ) {
 eat( 'mushrooms' );
 eat( 'mushrooms', 'slowly' );
 eat( 'dogfood', 'quickly' );
-[/php]
+```
 
 When more words are needed to describe the function parameters, an <code>$args</code> array may be a better pattern.
 
-[php]
+```php
 // Even Better
 function eat( $what, $args ) {
 ...
 }
 eat ( 'noodles', array( 'speed' => 'moderate' ) );
-[/php]
+```
 
 <h3>Interpolation for Naming Dynamic Hooks</h3>
 Dynamic hooks should be named using interpolation rather than concatenation for readability and discoverability purposes.
@@ -415,9 +415,9 @@ Dynamic hooks are hooks that include dynamic values in their tag name, e.g. <cod
 
 Variables used in hook tags should be wrapped in curly braces <code>{</code> and <code>}</code>, with the complete outer tag name wrapped in double quotes. This is to ensure PHP can correctly parse the given variables' types within the interpolated string.
 
-[php]
+```php
 do_action( "{$new_status}_{$post->post_type}", $post->ID, $post );
-[/php]
+```
 
 Where possible, dynamic values in tag names should also be as succinct and to the point as possible. <code>$user_id</code> is much more self-documenting than, say, <code>$this-&gt;id</code>.
 <h3>Ternary Operator</h3>
@@ -427,19 +427,19 @@ The short ternary operator must not be used.
 
 For example:
 
-[php]
+```php
 // (if statement is true) ? (do this) : (else, do this);
 $musictype = ( 'jazz' === $music ) ? 'cool' : 'blah';
 // (if field is not empty ) ? (do this) : (else, do this);
-[/php]
+```
 
 <h3>Yoda Conditions</h3>
 
-[php]
+```php
 if ( true === $the_force ) {
 	$victorious = you_will( $be );
 }
-[/php]
+```
 
 When doing logical comparisons involving variables, always put the variable on the right side and put constants, literals, or function calls on the left side. If neither side is a variable, the order is not important. (In <a href="https://en.wikipedia.org/wiki/Value_(computer_science)#Assignment:_l-values_and_r-values">computer science terms</a>, in comparisons always try to put l-values on the right and r-values on the left.)
 
@@ -451,58 +451,58 @@ This applies to ==, !=, ===, and !==. Yoda conditions for &lt;, &gt;, &lt;= or &
 <h3>Clever Code</h3>
 In general, readability is more important than cleverness or brevity.
 
-[php]
+```php
 isset( $var ) || $var = some_function();
-[/php]
+```
 
 Although the above line is clever, it takes a while to grok if you're not familiar with it. So, just write it like this:
 
-[php]
+```php
 if ( ! isset( $var ) ) {
 	$var = some_function();
 }
-[/php]
+```
 
 Unless absolutely necessary, loose comparisons should not be used, as their behaviour can be misleading.
 
 Correct:
 
-[php]
+```php
 if ( 0 === strpos( 'WordPress', 'foo' ) ) {
 	echo __( 'Yay WordPress!' );
 }
-[/php]
+```
 
 Incorrect:
 
-[php]
+```php
 if ( 0 == strpos( 'WordPress', 'foo' ) ) {
 	echo __( 'Yay WordPress!' );
 }
-[/php]
+```
 
 Assignments must not be placed in placed in conditionals.
 
 Correct:
 
-[php]
+```php
 $data = $wpdb->get_var( '...' );
 if ( $data ) {
     // Use $data
 }
-[/php]
+```
 
 Incorrect:
 
-[php]
+```php
 if ( $data = $wpdb->get_var( '...' ) ) {
     // Use $data
 }
-[/php]
+```
 
 In a <code>switch</code> statement, it's okay to have multiple empty cases fall through to a common block. If a case contains a block, then falls through to the next block, however, this must be explicitly commented.
 
-[php]
+```php
 switch ( $foo ) {
 	case 'bar':	      // Correct, an empty case can fall through without comment.
 	case 'baz':
@@ -517,7 +517,7 @@ switch ( $foo ) {
 		echo 'bird';
 		break;
 }
-[/php]
+```
 
 The <code>goto</code> statement must never be used.
 

--- a/wordpress-coding-standards/php.md
+++ b/wordpress-coding-standards/php.md
@@ -21,10 +21,10 @@ Your indentation should always reflect logical structure. Use <strong>real tabs<
 Exception: if you have a block of code that would be more readable if things are aligned, use spaces:
 
 ```php
-	$foo   = 'somevalue';
-	$foo2  = 'somevalue2';
-	$foo34 = 'somevalue3';
-	$foo5  = 'somevalue4';
+[tab]$foo   = 'somevalue';
+[tab]$foo2  = 'somevalue2';
+[tab]$foo34 = 'somevalue3';
+[tab]$foo5  = 'somevalue4';
 ```
 
 For associative arrays, <em>each item</em> should start on a new line when the array contains more than one item:
@@ -35,9 +35,9 @@ $query = new WP_Query( array( 'ID' => 123 ) );
 
 ```php
 $args = array(
-	'post_type'   => 'page',
-	'post_author' => 123,
-	'post_status' => 'publish',
+[tab]'post_type'   => 'page',
+[tab]'post_author' => 123,
+[tab]'post_status' => 'publish',
 );
  
 $query = new WP_Query( $args );
@@ -58,12 +58,12 @@ For <code>switch</code> structures <code>case</code> should indent one tab from 
 
 ```php
 switch ( $type ) {
-	case 'foo':
-		some_function();
-		break;
-	case 'bar':
-		some_function();
-		break;
+[tab]case 'foo':
+[tab][tab]some_function();
+[tab][tab]break;
+[tab]case 'bar':
+[tab][tab]some_function();
+[tab][tab]break;
 }
 ```
 


### PR DESCRIPTION
* Switches to using Markdown code fence notation instead of shortcodes
* Removes HTML entity substitutions as they are no longer necessary.

Style guide:
* Removes 'Shortcodes' section as shortcodes are no longer recommended. Markdown code fences, as described in prior section, is the preferred method.
* Escapes the code fence examples so the Markdown code fence notation themselves are shown. The examples intend to demonstrate the use of code fences (often with language hinting) but when unescaped this results in the code being formatted instead of shown.
* Adds an 'HTML' example to the 'Fenced Code Blocks' section as that appears to have been an oversight.

Fixes #44.