### PR TITLE
Update markdown_source

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,6 @@
 
 This repo contains the source for the [WordPress Coding Standards](https://developer.wordpress.org/coding-standards/) on https://developer.wordpress.org
 
-When creating new files, these must be added to the [manifest.json](https://github.com/WordPress-Coding-Standards/docs/blob/master/manifest.json) file. 
+When creating new files, these must be added to the [manifest.json](https://github.com/WordPress/wpcs-docs/blob/master/manifest.json) file. 
 
-Removing files also requires updating the [manifest.json](https://github.com/WordPress-Coding-Standards/docs/blob/master/manifest.json) file. After deletion and sync with DevHub, the page also needs to be manually deleted from DevHub.
+Removing files also requires updating the [manifest.json](https://github.com/WordPress/wpcs-docs/blob/master/manifest.json) file. After deletion and sync with DevHub, the page also needs to be manually deleted from DevHub.


### PR DESCRIPTION
Updated the name of the repository from `docs` to `wpcs-docs`