### PR TITLE
Adjust a tab level to fix div & PHP open/close

### DIFF
--- a/wordpress-coding-standards/php.md
+++ b/wordpress-coding-standards/php.md
@@ -182,14 +182,14 @@ Correct (Multiline):
 ```php
 function foo() {
     ?>
-        <div>
+    <div>
         <?php
         echo bar(
             $baz,
             $bat
         );
         ?>
-        </div>
+    </div>
     <?php
 }
 ```


### PR DESCRIPTION
We DO indent inside divs and we DON'T indent inside PHP open/close tags - correct?
In which case the indentation here seems incorrect - removing a level of tab from the div fixes both issues