### PR TITLE
Update of php.md - Opening and Closing PHP Tags Section

### DIFF
--- a/wordpress-coding-standards/php.md
+++ b/wordpress-coding-standards/php.md
@@ -200,12 +200,34 @@ Correct (Single Line):
 <input name="<?php echo esc_attr( $name ); ?>" />
 ```
 
+When embedding single lines of PHP within an HTML block, the PHP open and close tags must be on the same line as the PHP code, surrounding it.
+
+Correct:
+
+```php
+<div class="hfeed">
+   <?php while ( have_posts() ) : the_post(); ?>
+      <article id="someid class="someclass">
+         <!-- ... -->
+      </article>
+   <?php endwhile; ?>
+</div>
+```
+
 Incorrect:
 
 ```php
-if ( $a === $b ) { ?>
-<some html>
-<?php }
+<div class="hfeed">
+   <?php 
+   while ( have_posts() ) : the_post(); 
+      ?>
+         <article id="someid class="someclass">
+            <!-- ... -->
+         </article>
+      <?php 
+   endwhile; 
+   ?>
+</div>
 ```
 
 <h3>No Shorthand PHP Tags</h3>


### PR DESCRIPTION
The Opening and Closing PHP Tags Section - Specifically the case of single lines PHP inside HTML blocks was unclear and not full. Please see the above-proposed suggestion for edit and further improve that part of the documentation