### PR TITLE
Remove Changelog page

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,0 @@
-# Changelog
-
-- 2020-09-25 Update code examples to use Markdown code fence notation instead of shortcodes.
-- 2019-12-21 Update `javascript.md` from the [handbook page](https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/).
-- 2019-12-21 Update `accessibility.md` from the [handbook page](https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/).
-- 2018-01-14 Initial import from https://make.wordpress.org/core/handbook/best-practices/

--- a/manifest.json
+++ b/manifest.json
@@ -61,18 +61,11 @@
 		"parent": "inline-documentation-standards",
 		"markdown_source": "https://github.com/WordPress/wpcs-docs/blob/master/inline-documentation-standards/php.md"
 	},
-	"changelog": {
-		"title": "Changelog",
-		"slug": "changelog",
-		"parent": null,
-		"order": 3,
-		"markdown_source": "https://github.com/WordPress/wpcs-docs/blob/master/changelog.md"
-	},
 	"styleguide": {
 		"title": "Markdown Style Guide",
 		"slug": "styleguide",
 		"parent": null,
-		"order": 4,
+		"order": 3,
 		"markdown_source": "https://github.com/WordPress/wpcs-docs/blob/master/styleguide.md"
 	}
 }


### PR DESCRIPTION
As discussed in PR #65, the changelog page is not actively maintained and is out of date/out of sync with the actual changes which have been made, so we may as well remove it.