### PR TITLE
Update styleguide.md

### DIFF
--- a/styleguide.md
+++ b/styleguide.md
@@ -10,6 +10,7 @@
 ##### Heading h5
 ###### Heading h6
 ```
+
 Note: h1 - h4 items will be automatically added to the Table of Contents.
 
 ## Emphasis
@@ -23,6 +24,7 @@ This is _italic text_.
 ```
 
 ### Bold
+
 Wrap text with double `**` for **Bold** text:
 
 ```md
@@ -30,6 +32,7 @@ This is **bold text**.
 ```
 
 ### Strikethrough
+
 Wrap text with double `~~` for ~~strikethrough~~ text:
 
 ```md
@@ -79,6 +82,7 @@ Use numbered items followed by a `.:
 ## Horizontal Rules
 
 Use `---` for a horizontal rules:
+
 ```md
 ---
 ```
@@ -95,8 +99,9 @@ Use `---` for a horizontal rules:
 
 ### Inline Code
 
-Wrap inline code with <code>`\``</code> backticks:
-````
+Wrap inline code with single <code>`\``</code> backticks:
+
+````md
 ```
 This is `inline code` wrapped with backticks
 ```
@@ -107,7 +112,8 @@ When documenting an example, use the markdown <code>`\``</code> code block to de
 ### Fenced Code Blocks
 
 #### Javascript
-````
+
+````md
 ```javascript
 var foo = function (bar) {
   return bar++;
@@ -118,7 +124,8 @@ console.log(foo(5));
 ````
 
 #### JSON
-````
+
+````md
 ```json
 {
   "firstName": "John",
@@ -146,7 +153,8 @@ console.log(foo(5));
 ````
 
 #### CSS
-````
+
+````md
 ```css
 foo {
   padding: 5px;
@@ -160,7 +168,8 @@ foo {
 ````
 
 #### SCSS
-````
+
+````md
 ```scss
 foo {
   padding: 5px;
@@ -174,14 +183,16 @@ foo {
 ````
 
 #### HTML
-````
+
+````md
 ```html
 <span class="my-class">Example</span>
 ```
 ````
 
 #### PHP
-````
+
+````md
 ```php
 $array = array(
     "foo" => "bar",
@@ -191,7 +202,8 @@ $array = array(
 ````
 
 #### Markdown
-````
+
+````md
 ```md
 This is _italic text_. This is **bold text**.
 ```


### PR DESCRIPTION
Follow up to #66 to update markdown format for https://developer.wordpress.org/coding-standards/styleguide/

This resolves most issues with this file except for these two issues:
```
styleguide.md:102:30 MD033/no-inline-html Inline HTML [Element: code]
styleguide.md:110:47 MD033/no-inline-html Inline HTML [Element: code]
```

For the first and last lines of this section of code:

https://github.com/WordPress/wpcs-docs/blob/776433c94ca3dd529cf71b245f0f7897331744ae/styleguide.md#L98-L105

This had been previously tried, but the parser didn't like this change https://github.com/WordPress/wpcs-docs/commit/eb0aa61256caefb1230a6cb6a9a4557610b43af9#diff-43a6652a89d7d4621d2a09e2f299221d56063e27e66431443b319451e8e82e0a

Can possibly add an ignore-directive for markdownlint for this