### PR TITLE
Remove Unused Link

### DIFF
--- a/wordpress-coding-standards/javascript.md
+++ b/wordpress-coding-standards/javascript.md
@@ -285,7 +285,7 @@ window.wp = window.wp || {};
 
 ## Naming Conventions
 
-Variable and function names should be full words, using camel case with a lowercase first letter. This is an area where this standard differs from the [WordPress PHP coding standards](https://make.wordpress.org/core/handbook/coding-standards/php/#naming-conventions).
+Variable and function names should be full words, using camel case with a lowercase first letter. This is an area where this standard differs from the WordPress PHP coding standards.
 
 Names should be descriptive, but not excessively so. Exceptions are allowed for iterators, such as the use of `i` to represent the index in a loop.
 

--- a/wordpress-coding-standards/javascript.md
+++ b/wordpress-coding-standards/javascript.md
@@ -285,7 +285,7 @@ window.wp = window.wp || {};
 
 ## Naming Conventions
 
-Variable and function names should be full words, using camel case with a lowercase first letter. This is an area where this standard differs from the WordPress PHP coding standards.
+Variable and function names should be full words, using camel case with a lowercase first letter. This is an area where this standard differs from the [WordPress PHP coding standards](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/#naming-conventions).
 
 Names should be descriptive, but not excessively so. Exceptions are allowed for iterators, such as the use of `i` to represent the index in a loop.
 


### PR DESCRIPTION
Referring to the issue I created: https://github.com/WordPress/wpcs-docs/issues/78

There is no Naming Conventions topic or #naming-conventions anchor within the page. Therefore I have removed the link in this PR as it is no longer useful.