### PR TITLE
Use fully qualified names in inline code

### DIFF
--- a/wordpress-coding-standards/php.md
+++ b/wordpress-coding-standards/php.md
@@ -482,6 +482,24 @@ While import `use` statements can already be used in WordPress Core, it is, for 
 Import `use` statements are most useful when combined with namespaces and a class autoloading implementation.
 As neither of these are currently in place for WordPress Core and discussions about this are ongoing, holding off on adding import `use` statements to WordPress Core is the sensible choice for now.
 
+### Using fully qualified names in inline code
+
+When using a fully or partially qualified name, no whitespace or comments are allowed within the name.
+
+```php
+// Correct.
+$foo = new \Vendor\Domain\Foo();
+
+$result = namespace\function_name();
+
+// Incorrect.
+$foo = new \Vendor // Source: external dependency.
+           \Domain
+           \Foo();
+
+$result = namespace \function_name(); // Notice the space between namespace and \function_name().
+```
+
 ## Object-Oriented Programming
 
 ### Only One Object Structure (Class/Interface/Trait) per File

--- a/wordpress-coding-standards/php.md
+++ b/wordpress-coding-standards/php.md
@@ -500,6 +500,8 @@ $foo = new \Vendor // Source: external dependency.
 $result = namespace \function_name(); // Notice the space between namespace and \function_name().
 ```
 
+Note that as of PHP 8.0, using whitespace or comments within the name will throw a parse error.
+
 ## Object-Oriented Programming
 
 ### Only One Object Structure (Class/Interface/Trait) per File


### PR DESCRIPTION
This PR depends on #98. Once that is merged, this PR should be rebased to the master branch.

The PR adds rules about the fully qualified names in the inline code and is the continuation of the additions of 'modern' PHP code in the WordPress PHP Coding Standards handbook based on the [make post](https://make.wordpress.org/core/2020/03/20/updating-the-coding-standards-for-modern-php/) by Juliette Reinders Folmer.