### PR TITLE
The ::class constant

### DIFF
--- a/wordpress-coding-standards/php.md
+++ b/wordpress-coding-standards/php.md
@@ -441,6 +441,18 @@ This leaves, for now, only unconditionally declared functions in the global name
 
 Note: Using the `array` keyword in type declarations is **strongly discouraged** for now, as most often, it would be better to use `iterable` to allow for more flexibility in the implementation and that keyword is not yet available for use in WordPress Core until the minimum requirements are raised to PHP 7.1.
 
+### The ::class constant
+
+When using the `::class` constant for class name resolution, the `class` keyword should be in lowercase and there should be no spaces around the `::` operator.
+
+```php
+// Correct.
+add_action( 'action_name', array( My_Class::class, 'method_name' ) );
+ 
+// Incorrect.
+add_action( 'action_name', array( My_Class :: CLASS, 'method_name' ) );
+```
+
 ## Declare Statements, Namespace, and Import Statements
 
 ### Namespace declarations


### PR DESCRIPTION
This PR depends on #102. Once that is merged, this PR should be rebased to the master branch.

The PR adds rules about the `::class` constant and is the continuation of the additions of 'modern' PHP code in the WordPress PHP Coding Standards handbook based on the [make post](https://make.wordpress.org/core/2020/03/20/updating-the-coding-standards-for-modern-php/) by Juliette Reinders Folmer.