### PR TITLE
Instanceof and other operators

### DIFF
--- a/wordpress-coding-standards/php.md
+++ b/wordpress-coding-standards/php.md
@@ -143,7 +143,7 @@ Where possible, dynamic values in tag names should also be as succinct and to th
 
 ### Space Usage
 
-Always put spaces after commas, and on both sides of logical, comparison, string and assignment operators.
+Always put spaces after commas, and on both sides of logical, arithmetic, comparison, string and assignment operators.
 
 ```php
 SOME_CONST === 23;
@@ -152,6 +152,8 @@ foo() && bar();
 array( 1, 2, 3 );
 $baz . '-5';
 $term .= 'X';
+if( $object instanceof Post_Type_Interface ) { [...] };
+$result = 2 ** 3; // 8.
 ```
 
 Put spaces on both sides of the opening and closing parentheses of control structure blocks.


### PR DESCRIPTION
Update the list in the spacing section and added some new code examples.

The PR adds rules about the additional operators and is the continuation of the additions of 'modern' PHP code in the WordPress PHP Coding Standards handbook based on the [make post](https://make.wordpress.org/core/2020/03/20/updating-the-coding-standards-for-modern-php/) by Juliette Reinders Folmer.