### PR TITLE
Visibility should always be declared

### DIFF
--- a/wordpress-coding-standards/php.md
+++ b/wordpress-coding-standards/php.md
@@ -552,6 +552,31 @@ class Foo {
 }
 ```
 
+### Visibility should always be declared
+
+For all constructs that allow it (properties, methods, class constants since PHP 7.1), visibility should be explicitly declared.
+Using the `var` keyword for property declarations is not allowed.
+
+```php
+// Correct.
+class Foo {
+    public $foo;
+
+    protected function bar() {}
+}
+
+// Incorrect.
+class Foo {
+    var $foo;
+
+    function bar() {}
+}
+```
+
+_Usage in WordPress Core_
+
+Visibility for class constants can not be used in WordPress Core until the minimum PHP version has been raised to PHP 7.1.
+
 ## Control Structures
 
 ### Use `elseif`, not `else if`


### PR DESCRIPTION
This PR depends on #106. Once that is merged, this PR should be rebased to the master branch.

The PR adds rules about declaring visibility modifiers and is the continuation of the additions of 'modern' PHP code in the WordPress PHP Coding Standards handbook based on the [make post](https://make.wordpress.org/core/2020/03/20/updating-the-coding-standards-for-modern-php/) by Juliette Reinders Folmer.