### PR TITLE
Property and method modifier order

### DIFF
--- a/wordpress-coding-standards/php.md
+++ b/wordpress-coding-standards/php.md
@@ -710,6 +710,90 @@ _Usage in WordPress Core_
 
 Visibility for class constants can not be used in WordPress Core until the minimum PHP version has been raised to PHP 7.1.
 
+### Visibility and modifier order
+
+When using multiple modifiers for a class declaration, the order should be as follows:
+
+1. First the optional `abstract` or `final` modifier.
+2. Next, the optional `readonly` modifier.
+
+```php
+// Correct.
+abstract readonly class Foo {}
+
+// Incorrect.
+readonly final class Foo {}
+```
+
+When using multiple modifiers for a constant declaration inside object-oriented structures, the order should be as follows:
+
+1. First the optional `final` modifier.
+2. Next, the visibility modifier.
+
+```php
+// Correct.
+class Foo {
+    private const LABEL = 'Book';
+
+    final public const SLUG = 'book';
+}
+
+// Incorrect.
+interface Mailer {
+    protected final const SLUG = 'book';
+}
+```
+
+When using multiple modifiers for a property declaration, the order should be as follows:
+
+1. First a visibility modifier.
+2. Next, the optional `static` or `readonly` modifier (these keywords are mutually exclusive).
+3. Finally, the `type` declaration (if possible due to PHP version).
+
+```php
+// Correct.
+abstract class Foo {
+    public static $foo;
+
+    private readonly string $bar;
+}
+
+// Incorrect.
+class Foo {
+    static public $foo;
+
+    readonly private string $foo;
+}
+```
+
+When using multiple modifiers for a method declaration, the order should be as follows:
+
+1. First the optional `abstract` or `final` modifier.
+2. Then, a visibility modifier.
+3. Finally, the optional `static` modifier.
+
+```php
+// Correct.
+abstract class Foo {
+    abstract protected static function bar();
+}
+
+// Incorrect.
+class Foo {
+    static protected final function bar() {
+        // Code.
+    };
+}
+```
+
+[info]
+Visibility for OO constants can be declared since PHP 7.1.
+Typed properties are available since PHP 7.4.
+Readonly properties are available since PHP 8.1.
+`final` modifier for constants in object-oriented structures is available since PHP 8.1.
+Readonly classes are available since PHP 8.2.
+[/info]
+
 ## Control Structures
 
 ### Use `elseif`, not `else if`

--- a/wordpress-coding-standards/php.md
+++ b/wordpress-coding-standards/php.md
@@ -726,7 +726,7 @@ When using multiple modifiers for a _property declaration_, the order should be 
 
 1. First a visibility modifier.
 2. Next, the optional `static` or `readonly` modifier (these keywords are mutually exclusive).
-3. Finally, the `type` declaration (if possible due to PHP version).
+3. Finally, the optional `type` declaration.
 
 When using multiple modifiers for a _method declaration_, the order should be as follows:
 

--- a/wordpress-coding-standards/php.md
+++ b/wordpress-coding-standards/php.md
@@ -712,61 +712,23 @@ Visibility for class constants can not be used in WordPress Core until the minim
 
 ### Visibility and modifier order
 
-When using multiple modifiers for a class declaration, the order should be as follows:
+When using multiple modifiers for a _class declaration_, the order should be as follows:
 
 1. First the optional `abstract` or `final` modifier.
 2. Next, the optional `readonly` modifier.
 
-```php
-// Correct.
-abstract readonly class Foo {}
-
-// Incorrect.
-readonly final class Foo {}
-```
-
-When using multiple modifiers for a constant declaration inside object-oriented structures, the order should be as follows:
+When using multiple modifiers for a _constant declaration_ inside object-oriented structures, the order should be as follows:
 
 1. First the optional `final` modifier.
 2. Next, the visibility modifier.
 
-```php
-// Correct.
-class Foo {
-    private const LABEL = 'Book';
-
-    final public const SLUG = 'book';
-}
-
-// Incorrect.
-interface Mailer {
-    protected final const SLUG = 'book';
-}
-```
-
-When using multiple modifiers for a property declaration, the order should be as follows:
+When using multiple modifiers for a _property declaration_, the order should be as follows:
 
 1. First a visibility modifier.
 2. Next, the optional `static` or `readonly` modifier (these keywords are mutually exclusive).
 3. Finally, the `type` declaration (if possible due to PHP version).
 
-```php
-// Correct.
-abstract class Foo {
-    public static $foo;
-
-    private readonly string $bar;
-}
-
-// Incorrect.
-class Foo {
-    static public $foo;
-
-    readonly private string $foo;
-}
-```
-
-When using multiple modifiers for a method declaration, the order should be as follows:
+When using multiple modifiers for a _method declaration_, the order should be as follows:
 
 1. First the optional `abstract` or `final` modifier.
 2. Then, a visibility modifier.
@@ -774,12 +736,22 @@ When using multiple modifiers for a method declaration, the order should be as f
 
 ```php
 // Correct.
-abstract class Foo {
+abstract readonly class Foo {
+    private const LABEL = 'Book';
+    
+    public static $foo;
+    
+    private readonly string $bar;
+    
     abstract protected static function bar();
 }
 
 // Incorrect.
 class Foo {
+    protected final const SLUG = 'book';
+
+    static public $foo;
+    
     static protected final function bar() {
         // Code.
     };
@@ -787,11 +759,11 @@ class Foo {
 ```
 
 [info]
-Visibility for OO constants can be declared since PHP 7.1.
-Typed properties are available since PHP 7.4.
-Readonly properties are available since PHP 8.1.
-`final` modifier for constants in object-oriented structures is available since PHP 8.1.
-Readonly classes are available since PHP 8.2.
+- Visibility for OO constants can be declared since PHP 7.1.
+- Typed properties are available since PHP 7.4.
+- Readonly properties are available since PHP 8.1.
+- `final` modifier for constants in object-oriented structures is available since PHP 8.1.
+- Readonly classes are available since PHP 8.2.
 [/info]
 
 ## Control Structures


### PR DESCRIPTION
This PR depends on #107. Once that is merged, this PR should be rebased to the master branch.

The PR adds rules about the order of property and method modifiers and is the continuation of the additions of 'modern' PHP code in the WordPress PHP Coding Standards handbook based on the [make post](https://make.wordpress.org/core/2020/03/20/updating-the-coding-standards-for-modern-php/) by Juliette Reinders Folmer.