### PR TITLE
Object instantiation

### DIFF
--- a/wordpress-coding-standards/php.md
+++ b/wordpress-coding-standards/php.md
@@ -766,6 +766,22 @@ class Foo {
 - Readonly classes are available since PHP 8.2.
 [/info]
 
+### Object Instantiation
+
+When instantiating a new object instance, parenthesis must always be used, even when not strictly necessary.
+There should be no space between the name of the class being instantiated and the opening parenthesis.
+
+```php
+// Correct.
+$foo = new Foo();
+$anonymous_class = new class( $parameter ) { ... };
+$instance = new static();
+
+// Incorrect.
+$foo = new Foo;
+$anonymous_class = new class ( $input ) { ... };
+```
+
 ## Control Structures
 
 ### Use `elseif`, not `else if`


### PR DESCRIPTION
This PR depends on #108. Once that is merged, this PR should be rebased to the master branch.

The PR adds rules about the object instantiation and is the continuation of the additions of 'modern' PHP code in the WordPress PHP Coding Standards handbook based on the [make post](https://make.wordpress.org/core/2020/03/20/updating-the-coding-standards-for-modern-php/) by Juliette Reinders Folmer.