### PR TITLE
Function closing brace

### DIFF
--- a/wordpress-coding-standards/php.md
+++ b/wordpress-coding-standards/php.md
@@ -286,6 +286,8 @@ switch ( $type ) {
 
 Remove trailing whitespace at the end of each line. Omitting the closing PHP tag at the end of a file is preferred. If you use the tag, make sure you remove trailing whitespace.
 
+There should be no trailing blank lines at the end of a function body.
+
 ## Formatting
 
 ### Brace Style


### PR DESCRIPTION
This PR depends on #109. Once that is merged, this PR should be rebased to the master branch.

The PR adds rules about the function closing brace and is the continuation of the additions of 'modern' PHP code in the WordPress PHP Coding Standards handbook based on the [make post](https://make.wordpress.org/core/2020/03/20/updating-the-coding-standards-for-modern-php/) by Juliette Reinders Folmer.