### PR TITLE
Magic constants

### DIFF
--- a/wordpress-coding-standards/php.md
+++ b/wordpress-coding-standards/php.md
@@ -456,19 +456,21 @@ This leaves, for now, only unconditionally declared functions in the global name
 
 Note: Using the `array` keyword in type declarations is **strongly discouraged** for now, as most often, it would be better to use `iterable` to allow for more flexibility in the implementation and that keyword is not yet available for use in WordPress Core until the minimum requirements are raised to PHP 7.1.
 
-### The ::class constant
+### Magic constants
+
+The [PHP native `__*__` magic constants](https://www.php.net/manual/en/language.constants.magic.php), like `__CLASS__` and `__DIR__`, should be written in uppercase when used.
 
 When using the `::class` constant for class name resolution, the `class` keyword should be in lowercase and there should be no spaces around the `::` operator.
 
 ```php
 // Correct.
+add_action( 'action_name', array( __CLASS__, 'method_name' ) );
 add_action( 'action_name', array( My_Class::class, 'method_name' ) );
  
 // Incorrect.
+require_once __dIr__ . '/relative-path/file-name.php';
 add_action( 'action_name', array( My_Class :: CLASS, 'method_name' ) );
 ```
-
-The [PHP native `__*__` magic constants](https://www.php.net/manual/en/language.constants.magic.php), like `__CLASS__` and `__DIR__`, should be written in uppercase when used.
 
 ### Spread operator `...`
 

--- a/wordpress-coding-standards/php.md
+++ b/wordpress-coding-standards/php.md
@@ -468,6 +468,8 @@ add_action( 'action_name', array( My_Class::class, 'method_name' ) );
 add_action( 'action_name', array( My_Class :: CLASS, 'method_name' ) );
 ```
 
+The [PHP native `__*__` magic constants](https://www.php.net/manual/en/language.constants.magic.php), like `__CLASS__` and `__DIR__`, should be written in uppercase when used.
+
 ### Spread operator `...`
 
 When using the spread operator, there should be one space or a new line with the appropriate indentation before the spread operator. There should be no spaces between the spread operator and the variable/function call it applies to. When combining the spread operator with the reference operator (`&`), there should be no spaces between them.


### PR DESCRIPTION
This PR depends on #105. Once that is merged, this PR should be rebased to the master branch.

The PR adds rules about writing the magic constants and is the continuation of the additions of 'modern' PHP code in the WordPress PHP Coding Standards handbook based on the [make post](https://make.wordpress.org/core/2020/03/20/updating-the-coding-standards-for-modern-php/) by Juliette Reinders Folmer.