### PR TITLE
PHP docs: remove a duplication

### DIFF
--- a/wordpress-coding-standards/php.md
+++ b/wordpress-coding-standards/php.md
@@ -228,14 +228,6 @@ switch ( $foo ) {
 }
 ```
 
-Similarly, there should be no space before the colon on return type declarations.
-
-```php
-function sum( $a, $b ): float {
-    return $a + $b;
-}
-```
-
 Unless otherwise specified, parentheses should have spaces inside them.
 
 ```php


### PR DESCRIPTION
This same rule is also mentioned in the type declaration section (second paragrah).

Ref: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/#type-declarations