### PR TITLE
PHPdocs: discourage use of reserved keywords for parameter names

### DIFF
--- a/wordpress-coding-standards/php.md
+++ b/wordpress-coding-standards/php.md
@@ -103,6 +103,9 @@ Use lowercase letters in variable, action/filter, and function names (never `cam
 function some_name( $some_variable ) {}
 ```
 
+For function parameter names, it is _strongly recommended_ to avoid reserved keywords as names, as it leads to hard to read and confusing code when using the PHP 8.0 "named parameters in function calls" feature.
+Also keep in mind that renaming a function parameter should be considered a breaking change since PHP 8.0, so name function parameters with due care!
+
 Class, trait, interface and enum names should use capitalized words separated by underscores. Any acronyms should be all upper case.
 
 ```php


### PR DESCRIPTION
Most of this has already been fixed in WP Core as part of making Core compatible with PHP 8.0 and it would be great if no new instances of this issue would be introduced.

Ref:
* https://core.trac.wordpress.org/ticket/51553
* https://core.trac.wordpress.org/ticket/55327
* https://core.trac.wordpress.org/ticket/55650
* https://core.trac.wordpress.org/ticket/56788