### PR TITLE
Ensure comments example follows the standard

### DIFF
--- a/wordpress-coding-standards/javascript.md
+++ b/wordpress-coding-standards/javascript.md
@@ -359,6 +359,7 @@ Inline comments are allowed as an exception when used to annotate special argume
 
 ```javascript
 function foo( types, selector, data, fn, /* INTERNAL */ one ) {
+
 	// Do stuff
 }
 ```


### PR DESCRIPTION
In https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/#comments it states

> Comments come before the code to which they refer, and should always be preceded by a blank line.

The second example does not follow this rule. The `// Do stuff` comment is not preceded by a blank line.

I did not add a period here because I do not believe it is a "full sentence".