### PR TITLE
Updated external incorrect url

### DIFF
--- a/wordpress-coding-standards/html.md
+++ b/wordpress-coding-standards/html.md
@@ -93,4 +93,4 @@ Incorrect:
 
 ## Credits
 
-- HTML code standards adapted from [Fellowship Tech Code Standards](https://developer.fellowshipone.com/patterns/code.php) ([CC license](http://creativecommons.org/licenses/by-nc-sa/3.0/).
+- HTML code standards adapted from [Fellowship Tech Code Standards](https://developer.fellowshipone.com/patterns/code.php) ([CC license](http://creativecommons.org/licenses/by-nc-sa/3.0/)).

--- a/wordpress-coding-standards/html.md
+++ b/wordpress-coding-standards/html.md
@@ -93,4 +93,4 @@ Incorrect:
 
 ## Credits
 
-- HTML code standards adapted from [Fellowship Tech Code Standards](https://developer.fellowshipone.com/patterns/code.php) ([CC license](https://creativecommons.org/licenses/by-nc-sa/3.0/http://creativecommons.org/licenses/by-nc-sa/3.0/)).
+- HTML code standards adapted from [Fellowship Tech Code Standards](https://developer.fellowshipone.com/patterns/code.php) ([CC license](http://creativecommons.org/licenses/by-nc-sa/3.0/).

--- a/wordpress-coding-standards/html.md
+++ b/wordpress-coding-standards/html.md
@@ -93,4 +93,4 @@ Incorrect:
 
 ## Credits
 
-- HTML code standards adapted from [Fellowship Tech Code Standards](https://developer.fellowshipone.com/patterns/code.php) ([CC license](http://creativecommons.org/licenses/by-nc-sa/3.0/)).
+- HTML code standards adapted from [Fellowship Tech Code Standards](https://developer.fellowshipone.com/patterns/code.php) ([CC license](https://creativecommons.org/licenses/by-nc-sa/3.0/)).


### PR DESCRIPTION
Existing path url is duplicated and the link is therefore broken: https://creativecommons.org/licenses/by-nc-sa/3.0/http://creativecommons.org/licenses/by-nc-sa/3.0/

I have reduced to the correct url: https://creativecommons.org/licenses/by-nc-sa/3.0/