### PR TITLE
PHP/Trait Use Statements: minor tweak to "correct" example

### DIFF
--- a/wordpress-coding-standards/php.md
+++ b/wordpress-coding-standards/php.md
@@ -656,7 +656,9 @@ class Foo {
         Bar_Trait::method_name insteadof Bar_Trait;
         Bazinga_Trait::method_name as bazinga_method;
     }
-    use Loopy_Trait { eat as protected; }
+    use Loopy_Trait {
+        eat as protected;
+    }
 
     public $baz = true;
 


### PR DESCRIPTION
Allowing a single conflict resolution statement on the same line as the `use` decreases readability.

Changing this to a multi-line statement, with each conflict resolution statement on its own line, also improves consistency with other WP Core rules around the use of braces, as it makes the brace layout consistent with the expected brace layout for various control structures.