### PR TITLE
Clarify exceptions for using `@return void`

### DIFF
--- a/inline-documentation-standards/php.md
+++ b/inline-documentation-standards/php.md
@@ -194,7 +194,7 @@ Functions and class methods should be formatted as follows:
 - **`@link`**: URL that provides more information. This should never be used to reference another function, hook, class, or method, see `@see`.
 - **`@global`**: List PHP globals that are used within the function or method, with an optional description of the global. If multiple globals are listed, they should be aligned by type, variable, and description, with each other as a group.
 - **`@param`**: Note if the parameter is _Optional_ before the description, and include a period at the end. The description should mention accepted values as well as the default. For example: _Optional. This value does something. Accepts 'post', 'term', or empty. Default empty._
-- **`@return`**: Should contain all possible return types, and a description for each. Use a period at the end. Note: `@return void` should not be used outside of the default bundled themes.
+- **`@return`**: Should contain all possible return types, and a description for each. Use a period at the end. Note: `@return void` should not be used outside of the default bundled themes, third-party libraries, and PHP compatibility shims.
 
 ```php
 /**

--- a/inline-documentation-standards/php.md
+++ b/inline-documentation-standards/php.md
@@ -194,7 +194,7 @@ Functions and class methods should be formatted as follows:
 - **`@link`**: URL that provides more information. This should never be used to reference another function, hook, class, or method, see `@see`.
 - **`@global`**: List PHP globals that are used within the function or method, with an optional description of the global. If multiple globals are listed, they should be aligned by type, variable, and description, with each other as a group.
 - **`@param`**: Note if the parameter is _Optional_ before the description, and include a period at the end. The description should mention accepted values as well as the default. For example: _Optional. This value does something. Accepts 'post', 'term', or empty. Default empty._
-- **`@return`**: Should contain all possible return types, and a description for each. Use a period at the end. Note: `@return void` should not be used outside of the default bundled themes and PHP compatibility shims.
+- **`@return`**: Should contain all possible return types, and a description for each. Use a period at the end. Note: `@return void` should not be used outside of the default bundled themes and the Core included PHP compatibility shims.
 
 ```php
 /**

--- a/inline-documentation-standards/php.md
+++ b/inline-documentation-standards/php.md
@@ -194,7 +194,7 @@ Functions and class methods should be formatted as follows:
 - **`@link`**: URL that provides more information. This should never be used to reference another function, hook, class, or method, see `@see`.
 - **`@global`**: List PHP globals that are used within the function or method, with an optional description of the global. If multiple globals are listed, they should be aligned by type, variable, and description, with each other as a group.
 - **`@param`**: Note if the parameter is _Optional_ before the description, and include a period at the end. The description should mention accepted values as well as the default. For example: _Optional. This value does something. Accepts 'post', 'term', or empty. Default empty._
-- **`@return`**: Should contain all possible return types, and a description for each. Use a period at the end. Note: `@return void` should not be used outside of the default bundled themes, third-party libraries, and PHP compatibility shims.
+- **`@return`**: Should contain all possible return types, and a description for each. Use a period at the end. Note: `@return void` should not be used outside of the default bundled themes and PHP compatibility shims.
 
 ```php
 /**

--- a/inline-documentation-standards/php.md
+++ b/inline-documentation-standards/php.md
@@ -194,7 +194,7 @@ Functions and class methods should be formatted as follows:
 - **`@link`**: URL that provides more information. This should never be used to reference another function, hook, class, or method, see `@see`.
 - **`@global`**: List PHP globals that are used within the function or method, with an optional description of the global. If multiple globals are listed, they should be aligned by type, variable, and description, with each other as a group.
 - **`@param`**: Note if the parameter is _Optional_ before the description, and include a period at the end. The description should mention accepted values as well as the default. For example: _Optional. This value does something. Accepts 'post', 'term', or empty. Default empty._
-- **`@return`**: Should contain all possible return types, and a description for each. Use a period at the end. Note: `@return void` should not be used outside of the default bundled themes and the Core included PHP compatibility shims.
+- **`@return`**: Should contain all possible return types and a description for each. Use a period at the end. Note: `@return void` should not be used outside the default bundled themes and the PHP compatibility shims included in WordPress Core.
 
 ```php
 /**

--- a/wordpress-coding-standards.md
+++ b/wordpress-coding-standards.md
@@ -22,6 +22,6 @@ If you are planning to contribute to WordPress core, you need to familiarize you
 
 WordPress is committed to meeting the <a href="https://www.w3.org/TR/WCAG20/">Web Content Accessibility Guidelines (WCAG) at level AA</a> for all new and updated code. We've provided a <a href="https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/">quick guide to common accessibility issues</a> you should be aware of when creating patches or feature plug-ins. 
 
-<h2>Applying coding standards</h2>
+<h2>Where to (not) apply the coding standards</h2>
 
-The WordPress Coding Standards apply to WordPress code. Third-party libraries are not subject to these standards, even when bundled with the main project code. This may occasionally be the case, for example WordPress core bundles several third-party libraries in its codebase.
+Third-party libraries are not subject to these standards, even when bundled with the main project code. This may occasionally be the case, for example WordPress core bundles several third-party libraries in its codebase.

--- a/wordpress-coding-standards.md
+++ b/wordpress-coding-standards.md
@@ -21,3 +21,7 @@ If you are planning to contribute to WordPress core, you need to familiarize you
 <h2>Accessibility Standards</h2>
 
 WordPress is committed to meeting the <a href="https://www.w3.org/TR/WCAG20/">Web Content Accessibility Guidelines (WCAG) at level AA</a> for all new and updated code. We've provided a <a href="https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/">quick guide to common accessibility issues</a> you should be aware of when creating patches or feature plug-ins. 
+
+<h2>Applying coding standards</h2>
+
+The WordPress Coding Standards apply to WordPress code. Third-party libraries are not subject to these standards, even when bundled with the main project code. This may occasionally be the case, for example WordPress core bundles several third-party libraries in its codebase.

--- a/wordpress-coding-standards.md
+++ b/wordpress-coding-standards.md
@@ -22,6 +22,6 @@ If you are planning to contribute to WordPress core, you need to familiarize you
 
 WordPress is committed to meeting the <a href="https://www.w3.org/TR/WCAG20/">Web Content Accessibility Guidelines (WCAG) at level AA</a> for all new and updated code. We've provided a <a href="https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/">quick guide to common accessibility issues</a> you should be aware of when creating patches or feature plug-ins. 
 
-<h2>Where do the coding standards not apply?</h2>
+<h2>Where do the coding standards _not_ apply?</h2>
 
 Third-party libraries are not subject to these standards, even when integrated with the primary project. This includes instances like WordPress core, where multiple third-party libraries are incorporated into its codebase.

--- a/wordpress-coding-standards.md
+++ b/wordpress-coding-standards.md
@@ -24,4 +24,4 @@ WordPress is committed to meeting the <a href="https://www.w3.org/TR/WCAG20/">We
 
 <h2>Where to (not) apply the coding standards</h2>
 
-Third-party libraries are not subject to these standards, even when bundled with the main project code. This may occasionally be the case, for example WordPress core bundles several third-party libraries in its codebase.
+Third-party libraries are not subject to these standards, even when integrated with the primary project. This includes instances like WordPress core, where multiple third-party libraries are incorporated into its codebase.

--- a/wordpress-coding-standards.md
+++ b/wordpress-coding-standards.md
@@ -22,6 +22,6 @@ If you are planning to contribute to WordPress core, you need to familiarize you
 
 WordPress is committed to meeting the <a href="https://www.w3.org/TR/WCAG20/">Web Content Accessibility Guidelines (WCAG) at level AA</a> for all new and updated code. We've provided a <a href="https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/">quick guide to common accessibility issues</a> you should be aware of when creating patches or feature plug-ins. 
 
-<h2>Where to (not) apply the coding standards</h2>
+<h2>Where do the coding standards not apply?</h2>
 
 Third-party libraries are not subject to these standards, even when integrated with the primary project. This includes instances like WordPress core, where multiple third-party libraries are incorporated into its codebase.


### PR DESCRIPTION
See https://core.trac.wordpress.org/ticket/59619 and https://github.com/WordPress/wordpress-develop/pull/5484#pullrequestreview-1679058155: The current explanation that `@return void` should only be used outside of bundled themes is missing two other areas where that rule does not apply.