### PR TITLE
Update link to PHPCS to point to the new repository

### DIFF
--- a/wordpress-coding-standards/php.md
+++ b/wordpress-coding-standards/php.md
@@ -8,7 +8,7 @@ While not all code may fully comply with these standards (yet), all newly commit
 
 Also see the [PHP Inline Documentation Standards](https://developer.wordpress.org/coding-standards/inline-documentation-standards/php/) for further guidelines.
 
-If you want to automatically check your code against this standard, you can use the official [WordPress Coding Standards](https://github.com/WordPress/WordPress-Coding-Standards) tooling, which is run using [PHP_CodeSniffer](https://github.com/squizlabs/PHP_CodeSniffer/).
+If you want to automatically check your code against this standard, you can use the official [WordPress Coding Standards](https://github.com/WordPress/WordPress-Coding-Standards) tooling, which is run using [PHP_CodeSniffer](https://github.com/PHPCSStandards/PHP_CodeSniffer/).
 
 ## General
 


### PR DESCRIPTION
The documentation was pointing to the now abandoned https://github.com/squizlabs/PHP_CodeSniffer. This PR updates the link to point to https://github.com/PHPCSStandards/PHP_CodeSniffer/

Kudos to @ironprogrammer who found this and pinged me about it.

I searched this repository for `squizlabs` and this is the single occurrence that I found.