### PR TITLE
Update php.md

### DIFF
--- a/wordpress-coding-standards/php.md
+++ b/wordpress-coding-standards/php.md
@@ -51,20 +51,20 @@ if ( $a === $b ) { ?>
 
 ### No Shorthand PHP Tags
 
-**Important:** Never use shorthand PHP start tags. Always use full PHP tags.
+**Important:** Never use shorthand PHP start tags. Shorthand PHP echo tags are allowable.
 
 Correct:
 
 ```php
 <?php ... ?>
 <?php echo esc_html( $var ); ?>
+<?= esc_html( $var ) ?>
 ```
 
 Incorrect:
 
 ```php
 <? ... ?>
-<?= esc_html( $var ) ?>
 ```
 
 ### Single and Double Quotes


### PR DESCRIPTION
Short echo tags have no reason to be not allowed anymore. WordPress minimum PHP requirement is now 7.4, not <5.6, which seems to be the latest reason to not allow short echo tags. Reference: https://github.com/WordPress/WordPress-Coding-Standards/issues/1642