### PR TITLE
Update html.md

### DIFF
--- a/wordpress-coding-standards/html.md
+++ b/wordpress-coding-standards/html.md
@@ -55,7 +55,19 @@ Incorrect:
 <input type=text name=email disabled>
 ```
 
-In HTML, attributes do not all have to have values, and attribute values do not always have to be quoted. While all of the examples above are valid HTML, _failing to quote attributes can lead to security vulnerabilities_. Always quote attributes.
+In HTML, attributes do not all have to have values, and attribute values do not always have to be quoted. While all of the examples above are valid HTML, _failing to quote attributes can lead to security vulnerabilities_. Always quote attributes. Omitting the value on boolean attributes is allowed. The values `true` and `false` are not valid on boolean attributes ([HTML5 source](https://www.w3.org/TR/2011/WD-html5-20110405/common-microsyntaxes.html#boolean-attributes)).
+
+Correct:
+
+```html
+<input type="text" name="email" disabled />
+```
+
+Incorrect:
+
+```html
+<input type="text" name="email" disabled="true" />
+```
 
 ### Indentation
 


### PR DESCRIPTION
The XHTML specification was superseded in 2018, and the HTML specification is now considered the standard of reference. 

As such, while we can still reference the XHTML specification, there are places where XHTML standards conflict with HTML standards, such as the handling of boolean attributes. We should update the HTML standards to explicitly allow boolean attributes. See https://core.trac.wordpress.org/ticket/60178 for reference.