### PR TITLE
Fix a typo in the php documentation where Wordpress is missing an s

### DIFF
--- a/wordpress-coding-standards/php.md
+++ b/wordpress-coding-standards/php.md
@@ -608,7 +608,7 @@ Group `use` statements are available from PHP 7.0, and trailing commas in group 
 Note that, unless you have implemented [autoloading](https://www.php.net/manual/en/language.oop5.autoload.php), the `use` statement won't automatically load whatever is being imported. You'll either need to set up autoloading or load the file containing the class/function/constant using a `require/import` statement, for the imported constructs to be loaded when used.
 [/info]
 
-**Note about WordPres Core usage**
+**Note about WordPress Core usage**
 
 While import `use` statements can already be used in WordPress Core, it is, for the moment, **strongly discouraged**.
 


### PR DESCRIPTION
Whilst reading the developer docs I found a minor typo. This PR should fix said typo.