### PR TITLE
require/import vs require/include in PHP Coding Standards Documentation. - Fix for #143

### DIFF
--- a/wordpress-coding-standards/php.md
+++ b/wordpress-coding-standards/php.md
@@ -605,7 +605,8 @@ Group `use` statements are available from PHP 7.0, and trailing commas in group 
 [/alert]
 
 [info]
-Note that, unless you have implemented [autoloading](https://www.php.net/manual/en/language.oop5.autoload.php), the `use` statement won't automatically load referenced classes. You'll either need to set up autoloading or load the file containing the class using `require[_once]` or `include[_once]` statement, for the imported classes to be loaded when used. Autoloading is only applicable to classes; for functions and constants, you must always use `require[_once]` or `include[_once]`.
+Note that, unless you have implemented [autoloading](https://www.php.net/manual/en/language.oop5.autoload.php), the `use` statement won't automatically load whatever is being imported. For OO constructs, you'll either need to set up autoloading or load the file(s) containing the OO declaration(s) using `require[_once]` or `include[_once]` statements.
+Autoloading is only applicable to OO constructs; for functions and constants, you must always use `require[_once]` or `include[_once]`.
 [/info]
 
 **Note about WordPress Core usage**

--- a/wordpress-coding-standards/php.md
+++ b/wordpress-coding-standards/php.md
@@ -82,7 +82,7 @@ Text that goes into HTML or XML attributes should be escaped so that single or d
 
 Because `require[_once]` and `include[_once]` are language constructs, they do not need parentheses around the path, so those shouldn't be used. There should only be one space between the path and the require/include keywords.
 
-It is _strongly recommended_ to use `require[_once]` for unconditional includes. When using `include[_once]`, PHP will throw a warning when the file is not found but will continue execution, which will almost certainly lead to other errors/warnings/notices being thrown if your application depends on the file loaded, potentially leading to security leaks, or result in silent malfunctions which are hard to track down. For that reason, `require[_once]` is generally the better choice as it will throw a `Fatal Error` if the file cannot be found.
+It is _strongly recommended_ to use `require[_once]` for unconditional includes. When using `include[_once]`, PHP will throw a warning when the file is not found but will continue execution, which will almost certainly lead to other errors/warnings/notices being thrown if your application depends on the file loaded, potentially leading to security leaks. For that reason, `require[_once]` is generally the better choice as it will throw a `Fatal Error` if the file cannot be found.
 
 ```php
 // Correct.

--- a/wordpress-coding-standards/php.md
+++ b/wordpress-coding-standards/php.md
@@ -605,7 +605,7 @@ Group `use` statements are available from PHP 7.0, and trailing commas in group 
 [/alert]
 
 [info]
-Note that, unless you have implemented [autoloading](https://www.php.net/manual/en/language.oop5.autoload.php), the `use` statement won't automatically load whatever is being imported. You'll either need to set up autoloading or load the file containing the class/function/constant using a `require/include` statement, for the imported constructs to be loaded when used.
+Note that, unless you have implemented [autoloading](https://www.php.net/manual/en/language.oop5.autoload.php), the `use` statement won't automatically load referenced classes. You'll either need to set up autoloading or load the file containing the class using a `require/include` statement, for the imported classes to be loaded when used.Autoloading is only applicable to classes; for functions and constants, you must always use `require` or `include`.
 [/info]
 
 **Note about WordPress Core usage**

--- a/wordpress-coding-standards/php.md
+++ b/wordpress-coding-standards/php.md
@@ -605,7 +605,7 @@ Group `use` statements are available from PHP 7.0, and trailing commas in group 
 [/alert]
 
 [info]
-Note that, unless you have implemented [autoloading](https://www.php.net/manual/en/language.oop5.autoload.php), the `use` statement won't automatically load whatever is being imported. For OO constructs, you'll either need to set up autoloading or load the file(s) containing the OO declaration(s) using `require[_once]` or `include[_once]` statements.
+Note that, unless you have implemented [autoloading](https://www.php.net/manual/en/language.oop5.autoload.php), the `use` statement won't automatically load whatever is being imported. For OO constructs, you'll either need to set up autoloading or load the file(s) containing the OO declaration(s) using `require[_once]` or `include[_once]` statement(s).
 Autoloading is only applicable to OO constructs; for functions and constants, you must always use `require[_once]` or `include[_once]`.
 [/info]
 

--- a/wordpress-coding-standards/php.md
+++ b/wordpress-coding-standards/php.md
@@ -605,7 +605,7 @@ Group `use` statements are available from PHP 7.0, and trailing commas in group 
 [/alert]
 
 [info]
-Note that, unless you have implemented [autoloading](https://www.php.net/manual/en/language.oop5.autoload.php), the `use` statement won't automatically load whatever is being imported. You'll either need to set up autoloading or load the file containing the class/function/constant using a `require/import` statement, for the imported constructs to be loaded when used.
+Note that, unless you have implemented [autoloading](https://www.php.net/manual/en/language.oop5.autoload.php), the `use` statement won't automatically load whatever is being imported. You'll either need to set up autoloading or load the file containing the class/function/constant using a `require/include` statement, for the imported constructs to be loaded when used.
 [/info]
 
 **Note about WordPress Core usage**

--- a/wordpress-coding-standards/php.md
+++ b/wordpress-coding-standards/php.md
@@ -605,7 +605,7 @@ Group `use` statements are available from PHP 7.0, and trailing commas in group 
 [/alert]
 
 [info]
-Note that, unless you have implemented [autoloading](https://www.php.net/manual/en/language.oop5.autoload.php), the `use` statement won't automatically load referenced classes. You'll either need to set up autoloading or load the file containing the class using a `require/include` statement, for the imported classes to be loaded when used.Autoloading is only applicable to classes; for functions and constants, you must always use `require` or `include`.
+Note that, unless you have implemented [autoloading](https://www.php.net/manual/en/language.oop5.autoload.php), the `use` statement won't automatically load referenced classes. You'll either need to set up autoloading or load the file containing the class using a `require/include` statement, for the imported classes to be loaded when used. Autoloading is only applicable to classes; for functions and constants, you must always use `require` or `include`.
 [/info]
 
 **Note about WordPress Core usage**

--- a/wordpress-coding-standards/php.md
+++ b/wordpress-coding-standards/php.md
@@ -78,11 +78,11 @@ echo "<a href='{$escaped_link}'>text with a ' single quote</a>";
 
 Text that goes into HTML or XML attributes should be escaped so that single or double quotes do not end the attribute value and invalidate the HTML, causing a security issue. See [Data Validation](https://developer.wordpress.org/plugins/security/data-validation/) in the Plugin Handbook for further details.
 
-### Writing include/require statements
+### Writing require/include statements
 
-Because `include[_once]` and `require[_once]` are language constructs, they do not need parentheses around the path, so those shouldn't be used. There should only be one space between the path and the include/require keywords.
+Because `require[_once]` and `include[_once]` are language constructs, they do not need parentheses around the path, so those shouldn't be used. There should only be one space between the path and the require/include keywords.
 
-It is _strongly recommended_ to use `require[_once]` for unconditional includes. When using `include[_once]`, PHP will throw a warning when the file is not found but will continue execution, which will almost certainly lead to other errors/warnings/notices being thrown if your application depends on the file loaded, potentially leading to security leaks. For that reason, `require[_once]` is generally the better choice as it will throw a `Fatal Error` if the file cannot be found.
+It is _strongly recommended_ to use `require[_once]` for unconditional includes. When using `include[_once]`, PHP will throw a warning when the file is not found but will continue execution, which will almost certainly lead to other errors/warnings/notices being thrown if your application depends on the file loaded, potentially leading to security leaks, or result in silent malfunctions which are hard to track down. For that reason, `require[_once]` is generally the better choice as it will throw a `Fatal Error` if the file cannot be found.
 
 ```php
 // Correct.
@@ -605,7 +605,7 @@ Group `use` statements are available from PHP 7.0, and trailing commas in group 
 [/alert]
 
 [info]
-Note that, unless you have implemented [autoloading](https://www.php.net/manual/en/language.oop5.autoload.php), the `use` statement won't automatically load referenced classes. You'll either need to set up autoloading or load the file containing the class using `include[_once]` or `require[_once]` statement, for the imported classes to be loaded when used. Autoloading is only applicable to classes; for functions and constants, you must always use `include[_once]` or `require[_once]`.
+Note that, unless you have implemented [autoloading](https://www.php.net/manual/en/language.oop5.autoload.php), the `use` statement won't automatically load referenced classes. You'll either need to set up autoloading or load the file containing the class using `require[_once]` or `include[_once]` statement, for the imported classes to be loaded when used. Autoloading is only applicable to classes; for functions and constants, you must always use `require[_once]` or `include[_once]`.
 [/info]
 
 **Note about WordPress Core usage**

--- a/wordpress-coding-standards/php.md
+++ b/wordpress-coding-standards/php.md
@@ -605,7 +605,7 @@ Group `use` statements are available from PHP 7.0, and trailing commas in group 
 [/alert]
 
 [info]
-Note that, unless you have implemented [autoloading](https://www.php.net/manual/en/language.oop5.autoload.php), the `use` statement won't automatically load referenced classes. You'll either need to set up autoloading or load the file containing the class using a `require/include` statement, for the imported classes to be loaded when used. Autoloading is only applicable to classes; for functions and constants, you must always use `require` or `include`.
+Note that, unless you have implemented [autoloading](https://www.php.net/manual/en/language.oop5.autoload.php), the `use` statement won't automatically load referenced classes. You'll either need to set up autoloading or load the file containing the class using a `require/include` statement, for the imported classes to be loaded when used. Autoloading is only applicable to classes; for functions and constants, you must always use `require[_once]` or `include[_once]`.
 [/info]
 
 **Note about WordPress Core usage**

--- a/wordpress-coding-standards/php.md
+++ b/wordpress-coding-standards/php.md
@@ -605,7 +605,7 @@ Group `use` statements are available from PHP 7.0, and trailing commas in group 
 [/alert]
 
 [info]
-Note that, unless you have implemented [autoloading](https://www.php.net/manual/en/language.oop5.autoload.php), the `use` statement won't automatically load referenced classes. You'll either need to set up autoloading or load the file containing the class using a `require/include` statement, for the imported classes to be loaded when used. Autoloading is only applicable to classes; for functions and constants, you must always use `require[_once]` or `include[_once]`.
+Note that, unless you have implemented [autoloading](https://www.php.net/manual/en/language.oop5.autoload.php), the `use` statement won't automatically load referenced classes. You'll either need to set up autoloading or load the file containing the class using `include[_once]` or `require[_once]` statement, for the imported classes to be loaded when used. Autoloading is only applicable to classes; for functions and constants, you must always use `include[_once]` or `require[_once]`.
 [/info]
 
 **Note about WordPress Core usage**


### PR DESCRIPTION
This fixes #143 

Also taken care of @jrfnl 's comment on slack that autoloading only applies to classes and not to functions or constants.