### PR TITLE
Fix incorrect magic constant __dIr__ to __DIR__

### DIFF
--- a/wordpress-coding-standards/php.md
+++ b/wordpress-coding-standards/php.md
@@ -464,7 +464,7 @@ add_action( 'action_name', array( __CLASS__, 'method_name' ) );
 add_action( 'action_name', array( My_Class::class, 'method_name' ) );
 
 // Incorrect.
-require_once __dIr__ . '/relative-path/file-name.php';
+require_once __DIR__ . '/relative-path/file-name.php';
 add_action( 'action_name', array( My_Class :: CLASS, 'method_name' ) );
 ```
 


### PR DESCRIPTION
## Description:
This PR fixes a typo in the magic constant __dIr__, which is invalid.

### Fixes:
-> The correct constant __DIR__ is now used to ensure proper path resolution.