### PR TITLE
Use variable names of different lengths in DocBlock example

### DIFF
--- a/inline-documentation-standards/php.md
+++ b/inline-documentation-standards/php.md
@@ -206,8 +206,8 @@ Functions and class methods should be formatted as follows:
  *
  * @see Function/method/class relied on
  * @link URL
- * @global type $varname Description.
- * @global type $varname Description.
+ * @global type $variable_name    Description.
+ * @global type $another_variable Description.
  *
  * @param type $var Description.
  * @param type $var Optional. Description. Default.


### PR DESCRIPTION
If one global variable's name is longer than the other in the group, that can help demonstrate how they are "aligned by type, variable, and description."

- My suggestions for the names could be better.
- The `param` examples might benefit from a similar revision.