### PR TITLE
PHP: remove reference to POSIX regex functions

### DIFF
--- a/wordpress-coding-standards/php.md
+++ b/wordpress-coding-standards/php.md
@@ -1012,7 +1012,8 @@ Closures should not be passed as filter or action callbacks, as removing these v
 
 ### Regular Expressions
 
-Perl compatible regular expressions ([PCRE](https://www.php.net/pcre), `preg_` functions) should be used in preference to their POSIX counterparts. Never use the `/e` switch, use `preg_replace_callback` instead.
+Perl compatible regular expressions ([PCRE](https://www.php.net/pcre), `preg_` functions) should be used.
+Never use the `/e` switch, use `preg_replace_callback` instead.
 
 It's most convenient to use single-quoted strings for regular expressions since, contrary to double-quoted strings, they have only two metasequences which need escaping: `\'` and `\\`.
 


### PR DESCRIPTION
These were removed from PHP in PHP 7.0 and WP nowadays has a PHP 7.2 minimum, which means these function cannot be used anyhow, so this is no longer relevant.

Related to https://github.com/WordPress/WordPress-Coding-Standards/issues/2612