### PR TITLE
PHP: fix ambiguous wording in eval() paragraph

### DIFF
--- a/wordpress-coding-standards/php.md
+++ b/wordpress-coding-standards/php.md
@@ -991,7 +991,9 @@ switch ( $foo ) {
 
 The `goto` statement must never be used.
 
-The `eval()` construct is _very dangerous_ and is impossible to secure. Additionally, the `create_function()` function, which internally performs an `eval()`, is deprecated since PHP 7.2 and has been removed in PHP 8.0. These must not be used.
+The `eval()` construct is _very dangerous_ and is impossible to secure. It must not be used.
+
+The `create_function()` function internally performs an `eval()`. It was deprecated in PHP 7.2 and removed in PHP 8.0. It must not be used.
 
 ### Closures (Anonymous Functions)
 

--- a/wordpress-coding-standards/php.md
+++ b/wordpress-coding-standards/php.md
@@ -991,7 +991,7 @@ switch ( $foo ) {
 
 The `goto` statement must never be used.
 
-The `eval()` construct is _very dangerous_ and is impossible to secure. Additionally, the `create_function()` function, which internally performs an `eval()`, is deprecated since PHP 7.2 and has been removed in PHP 8.0. Neither of these must be used.
+The `eval()` construct is _very dangerous_ and is impossible to secure. Additionally, the `create_function()` function, which internally performs an `eval()`, is deprecated since PHP 7.2 and has been removed in PHP 8.0. These must not be used.
 
 ### Closures (Anonymous Functions)
 


### PR DESCRIPTION
The original sentence "Both of these must not be used" was changed to "Neither of these must be used" in 4361cec (PR #65), based on a [suggestion](https://github.com/WordPress/wpcs-docs/pull/65#discussion_r851789207) noting the original sentence read weird.

However, it seems to me that "Neither of these must be used" can be read as "there is no requirement to use either" instead of the intended prohibition.

This PR changes the sentence to "These must not be used", which keeps the clear prohibition from "must not".

Note: I'm not a native English speaker, so I could be wrong about the ambiguity. Happy to hear other opinions on this.