### PR TITLE
Harden the GitHub Actions workflow

### DIFF
--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -6,6 +6,8 @@ on:
   # Allow manually triggering the workflow.
   workflow_dispatch:
 
+permissions: {}
+
 # Cancels all previous workflow runs for the same branch that have not yet completed.
 concurrency:
   # The concurrency group contains the workflow name and the branch name.
@@ -18,9 +20,14 @@ jobs:
 
     runs-on: "ubuntu-latest"
 
+    permissions:
+      contents: read
+
     steps:
       - name: "Checkout"
-        uses: "actions/checkout@v4"
+        uses: "actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5" # v4.3.1
+        with:
+          persist-credentials: false
 
       - name: "Search for misspellings"
-        uses: "crate-ci/typos@v1"
+        uses: "crate-ci/typos@bbaefadf97b0ec5fdc942684b647f1a6ab250274" # v1.46.0

--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -6,6 +6,8 @@ on:
   # Allow manually triggering the workflow.
   workflow_dispatch:
 
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
 permissions: {}
 
 # Cancels all previous workflow runs for the same branch that have not yet completed.
@@ -21,7 +23,7 @@ jobs:
     runs-on: "ubuntu-latest"
 
     permissions:
-      contents: read
+      contents: read # Needed to checkout the repo.
 
     steps:
       - name: "Checkout"


### PR DESCRIPTION
Split out from #159, this hardens the GitHub Actions workflow in this repo and facilitates changing the [Settings -> Actions -> Workflow Permissions](https://github.com/WordPress/wpcs-docs/settings/actions) setting in this repo to read-only by default.

Combined, these changes greatly minimise the impact that a vulnerability in the CI workflow can have. The current configuration means that if, for example, the `crate-ci/typos` action was compromised, the write access that this workflow has could be exploited.

1. Tightens the permissions to what is minimally required, namely `contents: read` for the checkout.
2. Pins the third party action refs so they don't move.
3. Disables credential persistence on the git checkout. Just extra hardening at this point.

This addresses all issues reported by Actionlint and Zizmor. The security team are investigating the best way to apply scanning with those tools across the entire WordPress organisation on GitHub.